### PR TITLE
Correct typo (?) in memory layout docs

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -64,7 +64,7 @@
 //   - [2] => pointer to the duplicated expression
 //
 //   Lambda Node:
-//   - [0] => either and ERA or an ERA pointing to the variable location
+//   - [0] => either an ERA or an ARG pointing to the variable location
 //   - [1] => pointer to the lambda's body
 //   
 //   Application Node:


### PR DESCRIPTION
I don't see how an ERA can point to a variable location.