### PR TITLE
refactor: polyfill nightly functions and switch to stable rust.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,29 @@
+fn main() {
+  let target = std::env::var("TARGET").unwrap();
+  // This is is part of a larger workaround to support compiling on stable rust.
+  //
+  // This is the set of platforms that have been manually verified to have atomic integers with the
+  // same alignment as the normal integers. There are doubtless platforms that satisfy the
+  // requirement that aren't in the list, and should be added if anybody needs to compile for the
+  // platform. Pull requests welcome.
+  //
+  // This is a workaround for the unstable `cfg(target_has_atomic_equal_alignment = "n")` check, and
+  // should be removed once that or the `atomic_from_mut` and `atomic_mut_ptr` features are stable.
+  //
+  // See also `polyfills.rs`.
+  //
+  // See
+  // https://users.rust-lang.org/t/is-there-a-way-to-emulate-atomic-alignment-cfg-check-on-stable/87863/2
+  // for background on how to verify compatible platforms.
+  let targets_that_have_equal_alignments = &[
+    "wasm32-unknown-unknown",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "x86_64-pc-windows-msvc",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
+  ];
+  if targets_that_have_equal_alignments.contains(&target.as_str()) {
+    println!("cargo:rustc-cfg=stable_target_has_atomic_equal_alignment");
+  }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,7 +10,6 @@ pub fn eval(
   tids: usize,
   dbug: bool,
 ) -> Result<(String, u64, u64), String> {
-
   // Parses and reads the input file
   let file = language::syntax::read_file(&format!("{}\nHVM_MAIN_CALL = {}", file, term))?;
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -11,7 +11,7 @@ pub fn eval(
   dbug: bool,
 ) -> Result<(String, u64, u64), String> {
   // Parses and reads the input file
-  let file = language::syntax::read_file(&format!("{}\nHVM_MAIN_CALL = {}", file, term))?;
+  let file = language::syntax::read_file(&format!("{file}\nHVM_MAIN_CALL = {term}"))?;
 
   // Converts the file to a Rulebook
   let book = language::rulebook::gen_rulebook(&file);

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -5,134 +5,134 @@ mod compile;
 
 pub fn compile(code: &str, name: &str) -> std::io::Result<()> {
   let cargo_rs = include_str!("./../../Cargo.toml")
-    .replace("name = \"hvm\"", &format!("name = \"{}\"", name))
-    .replace("name = \"hvm\"", &format!("name = \"{}\"", name));
+    .replace("name = \"hvm\"", &format!("name = \"{name}\""))
+    .replace("name = \"hvm\"", &format!("name = \"{name}\""));
 
   // hvm
-  std::fs::create_dir(format!("./{}", name)).ok();
-  std::fs::write(format!("./{}/Cargo.toml", name), cargo_rs)?;
+  std::fs::create_dir(format!("./{name}")).ok();
+  std::fs::write(format!("./{name}/Cargo.toml"), cargo_rs)?;
   std::fs::write(
-    format!("./{}/rust-toolchain.toml", name),
+    format!("./{name}/rust-toolchain.toml"),
     include_str!("./../../rust-toolchain.toml"),
   )?;
 
   // hvm/src
-  std::fs::create_dir(format!("./{}/src", name)).ok();
-  std::fs::write(format!("./{}/src/main.rs", name), include_str!("./../main.rs"))?;
-  std::fs::write(format!("./{}/src/lib.rs", name), include_str!("./../lib.rs"))?;
-  std::fs::write(format!("./{}/src/api.rs", name), include_str!("./../api.rs"))?;
+  std::fs::create_dir(format!("./{name}/src")).ok();
+  std::fs::write(format!("./{name}/src/main.rs"), include_str!("./../main.rs"))?;
+  std::fs::write(format!("./{name}/src/lib.rs"), include_str!("./../lib.rs"))?;
+  std::fs::write(format!("./{name}/src/api.rs"), include_str!("./../api.rs"))?;
 
   // hvm/src/compiler
-  std::fs::create_dir(format!("./{}/src/compiler", name)).ok();
-  std::fs::write(format!("./{}/src/compiler/mod.rs", name), include_str!("./../compiler/mod.rs"))?;
+  std::fs::create_dir(format!("./{name}/src/compiler")).ok();
+  std::fs::write(format!("./{name}/src/compiler/mod.rs"), include_str!("./../compiler/mod.rs"))?;
   std::fs::write(
-    format!("./{}/src/compiler/compile.rs", name),
+    format!("./{name}/src/compiler/compile.rs"),
     include_str!("./../compiler/compile.rs"),
   )?;
 
   // hvm/src/language
-  std::fs::create_dir(format!("./{}/src/language", name)).ok();
-  std::fs::write(format!("./{}/src/language/mod.rs", name), include_str!("./../language/mod.rs"))?;
+  std::fs::create_dir(format!("./{name}/src/language")).ok();
+  std::fs::write(format!("./{name}/src/language/mod.rs"), include_str!("./../language/mod.rs"))?;
   std::fs::write(
-    format!("./{}/src/language/parser.rs", name),
+    format!("./{name}/src/language/parser.rs"),
     include_str!("./../language/parser.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/language/readback.rs", name),
+    format!("./{name}/src/language/readback.rs"),
     include_str!("./../language/readback.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/language/rulebook.rs", name),
+    format!("./{name}/src/language/rulebook.rs"),
     include_str!("./../language/rulebook.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/language/syntax.rs", name),
+    format!("./{name}/src/language/syntax.rs"),
     include_str!("./../language/syntax.rs"),
   )?;
 
   // hvm/src/runtime
-  std::fs::create_dir(format!("./{}/src/runtime", name)).ok();
-  std::fs::write(format!("./{}/src/runtime/mod.rs", name), include_str!("./../runtime/mod.rs"))?;
+  std::fs::create_dir(format!("./{name}/src/runtime")).ok();
+  std::fs::write(format!("./{name}/src/runtime/mod.rs"), include_str!("./../runtime/mod.rs"))?;
 
   // hvm/src/runtime/base
   let (precomp_rs, reducer_rs) = compile::build_code(code).unwrap();
-  std::fs::create_dir(format!("./{}/src/runtime/base", name)).ok();
+  std::fs::create_dir(format!("./{name}/src/runtime/base")).ok();
   std::fs::write(
-    format!("./{}/src/runtime/base/mod.rs", name),
+    format!("./{name}/src/runtime/base/mod.rs"),
     include_str!("./../runtime/base/mod.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/base/debug.rs", name),
+    format!("./{name}/src/runtime/base/debug.rs"),
     include_str!("./../runtime/base/debug.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/base/memory.rs", name),
+    format!("./{name}/src/runtime/base/memory.rs"),
     include_str!("./../runtime/base/memory.rs"),
   )?;
-  std::fs::write(format!("./{}/src/runtime/base/precomp.rs", name), precomp_rs)?;
+  std::fs::write(format!("./{name}/src/runtime/base/precomp.rs"), precomp_rs)?;
   std::fs::write(
-    format!("./{}/src/runtime/base/program.rs", name),
+    format!("./{name}/src/runtime/base/program.rs"),
     include_str!("./../runtime/base/program.rs"),
   )?;
-  std::fs::write(format!("./{}/src/runtime/base/reducer.rs", name), reducer_rs)?;
+  std::fs::write(format!("./{name}/src/runtime/base/reducer.rs"), reducer_rs)?;
 
   // hvm/src/runtime/data
-  std::fs::create_dir(format!("./{}/src/runtime/data", name)).ok();
+  std::fs::create_dir(format!("./{name}/src/runtime/data")).ok();
   std::fs::write(
-    format!("./{}/src/runtime/data/mod.rs", name),
+    format!("./{name}/src/runtime/data/mod.rs"),
     include_str!("./../runtime/data/mod.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/data/f60.rs", name),
+    format!("./{name}/src/runtime/data/f60.rs"),
     include_str!("./../runtime/data/f60.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/data/allocator.rs", name),
+    format!("./{name}/src/runtime/data/allocator.rs"),
     include_str!("./../runtime/data/allocator.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/data/barrier.rs", name),
+    format!("./{name}/src/runtime/data/barrier.rs"),
     include_str!("./../runtime/data/barrier.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/data/redex_bag.rs", name),
+    format!("./{name}/src/runtime/data/redex_bag.rs"),
     include_str!("./../runtime/data/redex_bag.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/data/u60.rs", name),
+    format!("./{name}/src/runtime/data/u60.rs"),
     include_str!("./../runtime/data/u60.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/data/u64_map.rs", name),
+    format!("./{name}/src/runtime/data/u64_map.rs"),
     include_str!("./../runtime/data/u64_map.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/data/visit_queue.rs", name),
+    format!("./{name}/src/runtime/data/visit_queue.rs"),
     include_str!("./../runtime/data/visit_queue.rs"),
   )?;
 
   // hvm/src/runtime/rule
-  std::fs::create_dir(format!("./{}/src/runtime/rule", name)).ok();
+  std::fs::create_dir(format!("./{name}/src/runtime/rule")).ok();
   std::fs::write(
-    format!("./{}/src/runtime/rule/mod.rs", name),
+    format!("./{name}/src/runtime/rule/mod.rs"),
     include_str!("./../runtime/rule/mod.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/rule/app.rs", name),
+    format!("./{name}/src/runtime/rule/app.rs"),
     include_str!("./../runtime/rule/app.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/rule/dup.rs", name),
+    format!("./{name}/src/runtime/rule/dup.rs"),
     include_str!("./../runtime/rule/dup.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/rule/fun.rs", name),
+    format!("./{name}/src/runtime/rule/fun.rs"),
     include_str!("./../runtime/rule/fun.rs"),
   )?;
   std::fs::write(
-    format!("./{}/src/runtime/rule/op2.rs", name),
+    format!("./{name}/src/runtime/rule/op2.rs"),
     include_str!("./../runtime/rule/op2.rs"),
   )?;
 
-  return Ok(());
+  Ok(())
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -4,67 +4,135 @@
 mod compile;
 
 pub fn compile(code: &str, name: &str) -> std::io::Result<()> {
-  
   let cargo_rs = include_str!("./../../Cargo.toml")
     .replace("name = \"hvm\"", &format!("name = \"{}\"", name))
     .replace("name = \"hvm\"", &format!("name = \"{}\"", name));
 
   // hvm
-  std::fs::create_dir(format!("./{}",name)).ok();
-  std::fs::write(format!("./{}/Cargo.toml",name), cargo_rs)?;
-  std::fs::write(format!("./{}/rust-toolchain.toml",name), include_str!("./../../rust-toolchain.toml"))?;
+  std::fs::create_dir(format!("./{}", name)).ok();
+  std::fs::write(format!("./{}/Cargo.toml", name), cargo_rs)?;
+  std::fs::write(
+    format!("./{}/rust-toolchain.toml", name),
+    include_str!("./../../rust-toolchain.toml"),
+  )?;
 
   // hvm/src
-  std::fs::create_dir(format!("./{}/src",name)).ok();
-  std::fs::write(format!("./{}/src/main.rs",name), include_str!("./../main.rs"))?;
-  std::fs::write(format!("./{}/src/lib.rs",name), include_str!("./../lib.rs"))?;
-  std::fs::write(format!("./{}/src/api.rs",name), include_str!("./../api.rs"))?;
+  std::fs::create_dir(format!("./{}/src", name)).ok();
+  std::fs::write(format!("./{}/src/main.rs", name), include_str!("./../main.rs"))?;
+  std::fs::write(format!("./{}/src/lib.rs", name), include_str!("./../lib.rs"))?;
+  std::fs::write(format!("./{}/src/api.rs", name), include_str!("./../api.rs"))?;
 
   // hvm/src/compiler
-  std::fs::create_dir(format!("./{}/src/compiler",name)).ok();
-  std::fs::write(format!("./{}/src/compiler/mod.rs",name)    , include_str!("./../compiler/mod.rs"))?;
-  std::fs::write(format!("./{}/src/compiler/compile.rs",name) , include_str!("./../compiler/compile.rs"))?;
+  std::fs::create_dir(format!("./{}/src/compiler", name)).ok();
+  std::fs::write(format!("./{}/src/compiler/mod.rs", name), include_str!("./../compiler/mod.rs"))?;
+  std::fs::write(
+    format!("./{}/src/compiler/compile.rs", name),
+    include_str!("./../compiler/compile.rs"),
+  )?;
 
   // hvm/src/language
-  std::fs::create_dir(format!("./{}/src/language",name)).ok();
-  std::fs::write(format!("./{}/src/language/mod.rs",name)      , include_str!("./../language/mod.rs"))?;
-  std::fs::write(format!("./{}/src/language/parser.rs",name)   , include_str!("./../language/parser.rs"))?;
-  std::fs::write(format!("./{}/src/language/readback.rs",name) , include_str!("./../language/readback.rs"))?;
-  std::fs::write(format!("./{}/src/language/rulebook.rs",name) , include_str!("./../language/rulebook.rs"))?;
-  std::fs::write(format!("./{}/src/language/syntax.rs",name)   , include_str!("./../language/syntax.rs"))?;
+  std::fs::create_dir(format!("./{}/src/language", name)).ok();
+  std::fs::write(format!("./{}/src/language/mod.rs", name), include_str!("./../language/mod.rs"))?;
+  std::fs::write(
+    format!("./{}/src/language/parser.rs", name),
+    include_str!("./../language/parser.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/language/readback.rs", name),
+    include_str!("./../language/readback.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/language/rulebook.rs", name),
+    include_str!("./../language/rulebook.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/language/syntax.rs", name),
+    include_str!("./../language/syntax.rs"),
+  )?;
 
   // hvm/src/runtime
-  std::fs::create_dir(format!("./{}/src/runtime",name)).ok();
-  std::fs::write(format!("./{}/src/runtime/mod.rs",name), include_str!("./../runtime/mod.rs"))?;
+  std::fs::create_dir(format!("./{}/src/runtime", name)).ok();
+  std::fs::write(format!("./{}/src/runtime/mod.rs", name), include_str!("./../runtime/mod.rs"))?;
 
   // hvm/src/runtime/base
   let (precomp_rs, reducer_rs) = compile::build_code(code).unwrap();
-  std::fs::create_dir(format!("./{}/src/runtime/base",name)).ok();
-  std::fs::write(format!("./{}/src/runtime/base/mod.rs",name)     , include_str!("./../runtime/base/mod.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/base/debug.rs",name)   , include_str!("./../runtime/base/debug.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/base/memory.rs",name)  , include_str!("./../runtime/base/memory.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/base/precomp.rs",name) , precomp_rs)?;
-  std::fs::write(format!("./{}/src/runtime/base/program.rs",name) , include_str!("./../runtime/base/program.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/base/reducer.rs",name) , reducer_rs)?;
+  std::fs::create_dir(format!("./{}/src/runtime/base", name)).ok();
+  std::fs::write(
+    format!("./{}/src/runtime/base/mod.rs", name),
+    include_str!("./../runtime/base/mod.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/base/debug.rs", name),
+    include_str!("./../runtime/base/debug.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/base/memory.rs", name),
+    include_str!("./../runtime/base/memory.rs"),
+  )?;
+  std::fs::write(format!("./{}/src/runtime/base/precomp.rs", name), precomp_rs)?;
+  std::fs::write(
+    format!("./{}/src/runtime/base/program.rs", name),
+    include_str!("./../runtime/base/program.rs"),
+  )?;
+  std::fs::write(format!("./{}/src/runtime/base/reducer.rs", name), reducer_rs)?;
 
   // hvm/src/runtime/data
-  std::fs::create_dir(format!("./{}/src/runtime/data",name)).ok();
-  std::fs::write(format!("./{}/src/runtime/data/mod.rs",name)         , include_str!("./../runtime/data/mod.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/data/f60.rs",name)         , include_str!("./../runtime/data/f60.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/data/allocator.rs",name)   , include_str!("./../runtime/data/allocator.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/data/barrier.rs",name)     , include_str!("./../runtime/data/barrier.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/data/redex_bag.rs",name)   , include_str!("./../runtime/data/redex_bag.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/data/u60.rs",name)         , include_str!("./../runtime/data/u60.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/data/u64_map.rs",name)     , include_str!("./../runtime/data/u64_map.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/data/visit_queue.rs",name) , include_str!("./../runtime/data/visit_queue.rs"))?;
+  std::fs::create_dir(format!("./{}/src/runtime/data", name)).ok();
+  std::fs::write(
+    format!("./{}/src/runtime/data/mod.rs", name),
+    include_str!("./../runtime/data/mod.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/data/f60.rs", name),
+    include_str!("./../runtime/data/f60.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/data/allocator.rs", name),
+    include_str!("./../runtime/data/allocator.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/data/barrier.rs", name),
+    include_str!("./../runtime/data/barrier.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/data/redex_bag.rs", name),
+    include_str!("./../runtime/data/redex_bag.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/data/u60.rs", name),
+    include_str!("./../runtime/data/u60.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/data/u64_map.rs", name),
+    include_str!("./../runtime/data/u64_map.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/data/visit_queue.rs", name),
+    include_str!("./../runtime/data/visit_queue.rs"),
+  )?;
 
   // hvm/src/runtime/rule
-  std::fs::create_dir(format!("./{}/src/runtime/rule",name)).ok();
-  std::fs::write(format!("./{}/src/runtime/rule/mod.rs",name) , include_str!("./../runtime/rule/mod.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/rule/app.rs",name) , include_str!("./../runtime/rule/app.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/rule/dup.rs",name) , include_str!("./../runtime/rule/dup.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/rule/fun.rs",name) , include_str!("./../runtime/rule/fun.rs"))?;
-  std::fs::write(format!("./{}/src/runtime/rule/op2.rs",name) , include_str!("./../runtime/rule/op2.rs"))?;
+  std::fs::create_dir(format!("./{}/src/runtime/rule", name)).ok();
+  std::fs::write(
+    format!("./{}/src/runtime/rule/mod.rs", name),
+    include_str!("./../runtime/rule/mod.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/rule/app.rs", name),
+    include_str!("./../runtime/rule/app.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/rule/dup.rs", name),
+    include_str!("./../runtime/rule/dup.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/rule/fun.rs", name),
+    include_str!("./../runtime/rule/fun.rs"),
+  )?;
+  std::fs::write(
+    format!("./{}/src/runtime/rule/op2.rs", name),
+    include_str!("./../runtime/rule/op2.rs"),
+  )?;
 
   return Ok(());
 }

--- a/src/language/parser.rs
+++ b/src/language/parser.rs
@@ -387,7 +387,11 @@ pub fn name1(state: State) -> Answer<String> {
 // ======
 
 pub fn expected<'a, A>(name: &str, size: usize, state: State<'a>) -> Answer<'a, A> {
-  Err(format!("Expected `{}`:\n{}", name, &highlight_error::highlight_error(state.index, state.index + size, state.code)))
+  Err(format!(
+    "Expected `{}`:\n{}",
+    name,
+    &highlight_error::highlight_error(state.index, state.index + size, state.code)
+  ))
 }
 
 // Tests

--- a/src/language/parser.rs
+++ b/src/language/parser.rs
@@ -49,7 +49,7 @@ pub type Parser<'a, A> = Box<dyn Fn(State<'a>) -> Answer<'a, A>>;
 // =====
 
 pub fn find(text: &str, target: &str) -> usize {
-  text.find(target).unwrap_or_else(|| panic!("`{}` not in `{}`.", target, text))
+  text.find(target).unwrap_or_else(|| panic!("`{target}` not in `{text}`."))
 }
 
 pub fn read<'a, A>(parser: Parser<'a, A>, code: &'a str) -> Result<A, String> {
@@ -94,9 +94,9 @@ pub fn get_char(state: State) -> Answer<char> {
 pub fn peek_char(state: State) -> Answer<char> {
   let (state, _) = skip(state)?;
   if let Some(got) = head(state) {
-    return Ok((state, got));
+    Ok((state, got))
   } else {
-    return Ok((state, '\0'));
+    Ok((state, '\0'))
   }
 }
 

--- a/src/language/readback.rs
+++ b/src/language/readback.rs
@@ -117,7 +117,7 @@ pub fn as_term(heap: &Heap, prog: &Program, host: u64) -> Box<language::syntax::
           "*".to_string()
         } else {
           let var = runtime::Var(runtime::get_loc(term, 0));
-          ctx.names.get(&var).cloned().unwrap_or("?".to_string())
+          ctx.names.get(&var).cloned().unwrap_or_else(|| "?".to_string())
         };
         Box::new(language::syntax::Term::Lam { name, body })
       }

--- a/src/language/rulebook.rs
+++ b/src/language/rulebook.rs
@@ -96,13 +96,13 @@ pub fn add_group(book: &mut RuleBook, name: &str, group: &RuleGroup) {
         }
         // Force strictness when pattern-matching
         if lhs_top {
-          for i in 0..args.len() {
-            let is_strict = match *args[i] {
-              language::syntax::Term::Ctr { .. } => true,
-              language::syntax::Term::U6O { .. } => true,
-              language::syntax::Term::F6O { .. } => true,
-              _ => false,
-            };
+          for (i, arg) in args.iter().enumerate() {
+            let is_strict = matches!(
+              **arg,
+              language::syntax::Term::Ctr { .. }
+                | language::syntax::Term::U6O { .. }
+                | language::syntax::Term::F6O { .. }
+            );
             if is_strict {
               book.id_to_smap.get_mut(&id).unwrap()[i] = true;
             }
@@ -305,7 +305,7 @@ pub fn sanitize_rule(rule: &language::syntax::Rule) -> Result<language::syntax::
         if is_global_0 != is_global_1 {
           panic!("Both variables must be global: '{nam0}' and '{nam1}'.");
         }
-        if is_global_0 && &nam0[2..] != &nam1[2..] {
+        if is_global_0 && nam0[2..] != nam1[2..] {
           panic!("Global dup names must be identical: '{nam0}' and '{nam1}'.");
         }
         let new_nam0 = if is_global_0 { nam0.clone() } else { (ctx.fresh)() };
@@ -1042,7 +1042,7 @@ pub fn flatten(rules: &[language::syntax::Rule]) -> Vec<language::syntax::Rule> 
 
   // For each group, split its internal rules
   let mut new_rules = Vec::new();
-  for (_name, rules) in &groups {
+  for rules in groups.values() {
     for rule in split_group(rules, &mut name_count) {
       new_rules.push(rule);
     }

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -10,16 +10,48 @@ use crate::runtime::data::u60;
 
 #[derive(Clone, Debug)]
 pub enum Term {
-  Var { name: String }, // TODO: add `global: bool`
-  Dup { nam0: String, nam1: String, expr: Box<Term>, body: Box<Term> },
-  Sup { val0: Box<Term>, val1: Box<Term> },
-  Let { name: String, expr: Box<Term>, body: Box<Term> },
-  Lam { name: String, body: Box<Term> },
-  App { func: Box<Term>, argm: Box<Term> },
-  Ctr { name: String, args: Vec<Box<Term>> },
-  U6O { numb: u64 },
-  F6O { numb: u64 },
-  Op2 { oper: Oper, val0: Box<Term>, val1: Box<Term> },
+  Var {
+    name: String,
+  }, // TODO: add `global: bool`
+  Dup {
+    nam0: String,
+    nam1: String,
+    expr: Box<Term>,
+    body: Box<Term>,
+  },
+  Sup {
+    val0: Box<Term>,
+    val1: Box<Term>,
+  },
+  Let {
+    name: String,
+    expr: Box<Term>,
+    body: Box<Term>,
+  },
+  Lam {
+    name: String,
+    body: Box<Term>,
+  },
+  App {
+    func: Box<Term>,
+    argm: Box<Term>,
+  },
+  #[allow(clippy::vec_box)]
+  Ctr {
+    name: String,
+    args: Vec<Box<Term>>,
+  },
+  U6O {
+    numb: u64,
+  },
+  F6O {
+    numb: u64,
+  },
+  Op2 {
+    oper: Oper,
+    val0: Box<Term>,
+    val1: Box<Term>,
+  },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -328,21 +360,15 @@ pub fn parse_num(state: parser::State) -> parser::Answer<Option<Box<Term>>> {
     Box::new(|state| {
       let (state, text) = parser::name1(state)?;
       if !text.is_empty() {
-        if text.starts_with("0x") {
+        if let Some(text) = text.strip_prefix("0x") {
           Ok((
             state,
-            Box::new(Term::U6O { numb: u60::new(u64::from_str_radix(&text[2..], 16).unwrap()) }),
+            Box::new(Term::U6O { numb: u60::new(u64::from_str_radix(text, 16).unwrap()) }),
           ))
         } else if text.find('.').is_some() {
-          Ok((
-            state,
-            Box::new(Term::F6O { numb: f60::new(text.parse::<f64>().unwrap()) }),
-          ))
+          Ok((state, Box::new(Term::F6O { numb: f60::new(text.parse::<f64>().unwrap()) })))
         } else {
-          Ok((
-            state,
-            Box::new(Term::U6O { numb: u60::new(text.parse::<u64>().unwrap()) }),
-          ))
+          Ok((state, Box::new(Term::U6O { numb: u60::new(text.parse::<u64>().unwrap()) })))
         }
       } else {
         Ok((state, Box::new(Term::U6O { numb: 0 })))

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -1,6 +1,6 @@
 use crate::language::parser;
-use crate::runtime::data::u60;
 use crate::runtime::data::f60;
+use crate::runtime::data::u60;
 
 // Types
 // =====
@@ -24,10 +24,22 @@ pub enum Term {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Oper {
-  Add, Sub, Mul, Div,
-  Mod, And, Or,  Xor,
-  Shl, Shr, Lte, Ltn,
-  Eql, Gte, Gtn, Neq,
+  Add,
+  Sub,
+  Mul,
+  Div,
+  Mod,
+  And,
+  Or,
+  Xor,
+  Shl,
+  Shr,
+  Lte,
+  Ltn,
+  Eql,
+  Gte,
+  Gtn,
+  Neq,
 }
 
 // Rule
@@ -60,24 +72,28 @@ pub struct File {
 
 impl std::fmt::Display for Oper {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", match self {
-      Self::Add => "+",
-      Self::Sub => "-",
-      Self::Mul => "*",
-      Self::Div => "/",
-      Self::Mod => "%",
-      Self::And => "&",
-      Self::Or  => "|",
-      Self::Xor => "^",
-      Self::Shl => "<<",
-      Self::Shr => ">>",
-      Self::Lte => "<=",
-      Self::Ltn => "<",
-      Self::Eql => "==",
-      Self::Gte => ">=",
-      Self::Gtn => ">",
-      Self::Neq => "!=",
-    })
+    write!(
+      f,
+      "{}",
+      match self {
+        Self::Add => "+",
+        Self::Sub => "-",
+        Self::Mul => "*",
+        Self::Div => "/",
+        Self::Mod => "%",
+        Self::And => "&",
+        Self::Or => "|",
+        Self::Xor => "^",
+        Self::Shl => "<<",
+        Self::Shr => ">>",
+        Self::Lte => "<=",
+        Self::Ltn => "<",
+        Self::Eql => "==",
+        Self::Gte => ">=",
+        Self::Gtn => ">",
+        Self::Neq => "!=",
+      }
+    )
   }
 }
 
@@ -133,7 +149,9 @@ impl std::fmt::Display for Term {
     }
     match self {
       Self::Var { name } => write!(f, "{}", name),
-      Self::Dup { nam0, nam1, expr, body } => write!(f, "dup {} {} = {}; {}", nam0, nam1, expr, body),
+      Self::Dup { nam0, nam1, expr, body } => {
+        write!(f, "dup {} {} = {}; {}", nam0, nam1, expr, body)
+      }
       Self::Sup { val0, val1 } => write!(f, "{{{} {}}}", val0, val1),
       Self::Let { name, expr, body } => write!(f, "let {} = {}; {}", name, expr, body),
       Self::Lam { name, body } => write!(f, "λ{} {}", name, body),
@@ -145,8 +163,13 @@ impl std::fmt::Display for Term {
           expr = func;
         }
         args.reverse();
-        write!(f, "({} {})", expr, args.iter().map(|x| format!("{}",x)).collect::<Vec<String>>().join(" "))
-      },
+        write!(
+          f,
+          "({} {})",
+          expr,
+          args.iter().map(|x| format!("{}", x)).collect::<Vec<String>>().join(" ")
+        )
+      }
       Self::Ctr { name, args } => {
         // Ctr sugars
         let sugars = [str_sugar, lst_sugar];
@@ -179,7 +202,11 @@ impl std::fmt::Display for Rule {
 
 impl std::fmt::Display for File {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.rules.iter().map(|rule| format!("{}", rule)).collect::<Vec<String>>().join("\n"))
+    write!(
+      f,
+      "{}",
+      self.rules.iter().map(|rule| format!("{}", rule)).collect::<Vec<String>>().join("\n")
+    )
   }
 }
 
@@ -190,11 +217,11 @@ pub fn parse_let(state: parser::State) -> parser::Answer<Option<Box<Term>>> {
   return parser::guard(
     parser::text_parser("let "),
     Box::new(|state| {
-      let (state, _)    = parser::consume("let ", state)?;
+      let (state, _) = parser::consume("let ", state)?;
       let (state, name) = parser::name1(state)?;
-      let (state, _)    = parser::consume("=", state)?;
+      let (state, _) = parser::consume("=", state)?;
       let (state, expr) = parse_term(state)?;
-      let (state, _)    = parser::text(";", state)?;
+      let (state, _) = parser::text(";", state)?;
       let (state, body) = parse_term(state)?;
       Ok((state, Box::new(Term::Let { name, expr, body })))
     }),
@@ -206,12 +233,12 @@ pub fn parse_dup(state: parser::State) -> parser::Answer<Option<Box<Term>>> {
   return parser::guard(
     parser::text_parser("dup "),
     Box::new(|state| {
-      let (state, _)    = parser::consume("dup ", state)?;
+      let (state, _) = parser::consume("dup ", state)?;
       let (state, nam0) = parser::name1(state)?;
       let (state, nam1) = parser::name1(state)?;
-      let (state, _)    = parser::consume("=", state)?;
+      let (state, _) = parser::consume("=", state)?;
       let (state, expr) = parse_term(state)?;
-      let (state, _)    = parser::text(";", state)?;
+      let (state, _) = parser::text(";", state)?;
       let (state, body) = parse_term(state)?;
       Ok((state, Box::new(Term::Dup { nam0, nam1, expr, body })))
     }),
@@ -223,10 +250,10 @@ pub fn parse_sup(state: parser::State) -> parser::Answer<Option<Box<Term>>> {
   parser::guard(
     parser::text_parser("{"),
     Box::new(move |state| {
-      let (state, _)    = parser::consume("{", state)?;
+      let (state, _) = parser::consume("{", state)?;
       let (state, val0) = parse_term(state)?;
       let (state, val1) = parse_term(state)?;
-      let (state, _)    = parser::consume("}", state)?;
+      let (state, _) = parser::consume("}", state)?;
       Ok((state, Box::new(Term::Sup { val0, val1 })))
     }),
     state,
@@ -239,7 +266,7 @@ pub fn parse_lam(state: parser::State) -> parser::Answer<Option<Box<Term>>> {
   parser::guard(
     Box::new(parse_symbol),
     Box::new(move |state| {
-      let (state, _)    = parse_symbol(state)?;
+      let (state, _) = parse_symbol(state)?;
       let (state, name) = parser::name(state)?;
       let (state, body) = parse_term(state)?;
       Ok((state, Box::new(Term::Lam { name, body })))
@@ -302,12 +329,21 @@ pub fn parse_num(state: parser::State) -> parser::Answer<Option<Box<Term>>> {
       let (state, text) = parser::name1(state)?;
       if !text.is_empty() {
         if text.starts_with("0x") {
-          return Ok((state, Box::new(Term::U6O { numb: u60::new(u64::from_str_radix(&text[2..], 16).unwrap()) })));
+          return Ok((
+            state,
+            Box::new(Term::U6O { numb: u60::new(u64::from_str_radix(&text[2..], 16).unwrap()) }),
+          ));
         } else {
           if text.find(".").is_some() {
-            return Ok((state, Box::new(Term::F6O { numb: f60::new(text.parse::<f64>().unwrap()) })));
+            return Ok((
+              state,
+              Box::new(Term::F6O { numb: f60::new(text.parse::<f64>().unwrap()) }),
+            ));
           } else {
-            return Ok((state, Box::new(Term::U6O { numb: u60::new(text.parse::<u64>().unwrap()) })));
+            return Ok((
+              state,
+              Box::new(Term::U6O { numb: u60::new(text.parse::<u64>().unwrap()) }),
+            ));
           }
         }
       } else {
@@ -389,7 +425,7 @@ pub fn parse_sym_sugar(state: parser::State) -> parser::Answer<Option<Box<Term>>
   parser::guard(
     parser::text_parser("%"),
     Box::new(|state| {
-      let (state, _)    = parser::text("%", state)?;
+      let (state, _) = parser::text("%", state)?;
       let (state, name) = parser::name(state)?;
       let hash = {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -414,11 +450,11 @@ pub fn parse_ask_sugar_named(state: parser::State) -> parser::Answer<Option<Box<
       Ok((state, asks && name.len() > 0 && eqls))
     }),
     Box::new(|state| {
-      let (state, _)    = parser::consume("ask ", state)?;
+      let (state, _) = parser::consume("ask ", state)?;
       let (state, name) = parser::name1(state)?;
-      let (state, _)    = parser::consume("=", state)?;
+      let (state, _) = parser::consume("=", state)?;
       let (state, func) = parse_term(state)?;
-      let (state, _)    = parser::text(";", state)?;
+      let (state, _) = parser::text(";", state)?;
       let (state, body) = parse_term(state)?;
       Ok((state, Box::new(Term::App { func, argm: Box::new(Term::Lam { name, body }) })))
     }),
@@ -430,11 +466,14 @@ pub fn parse_ask_sugar_anon(state: parser::State) -> parser::Answer<Option<Box<T
   return parser::guard(
     parser::text_parser("ask "),
     Box::new(|state| {
-      let (state, _)    = parser::consume("ask ", state)?;
+      let (state, _) = parser::consume("ask ", state)?;
       let (state, func) = parse_term(state)?;
-      let (state, _)    = parser::text(";", state)?;
+      let (state, _) = parser::text(";", state)?;
       let (state, body) = parse_term(state)?;
-      Ok((state, Box::new(Term::App { func, argm: Box::new(Term::Lam { name: "*".to_string(), body }) })))
+      Ok((
+        state,
+        Box::new(Term::App { func, argm: Box::new(Term::Lam { name: "*".to_string(), body }) }),
+      ))
     }),
     state,
   );
@@ -528,15 +567,15 @@ pub fn parse_if_sugar(state: parser::State) -> parser::Answer<Option<Box<Term>>>
   return parser::guard(
     parser::text_parser("if "),
     Box::new(|state| {
-      let (state, _)    = parser::consume("if ", state)?;
+      let (state, _) = parser::consume("if ", state)?;
       let (state, cond) = parse_term(state)?;
-      let (state, _)    = parser::consume("{", state)?;
+      let (state, _) = parser::consume("{", state)?;
       let (state, if_t) = parse_term(state)?;
-      let (state, _)    = parser::consume("}", state)?;
-      let (state, _)    = parser::consume("else", state)?;
-      let (state, _)    = parser::consume("{", state)?;
+      let (state, _) = parser::consume("}", state)?;
+      let (state, _) = parser::consume("else", state)?;
+      let (state, _) = parser::consume("{", state)?;
       let (state, if_f) = parse_term(state)?;
-      let (state, _)    = parser::consume("}", state)?;
+      let (state, _) = parser::consume("}", state)?;
       Ok((state, Box::new(Term::Ctr { name: "U60.if".to_string(), args: vec![cond, if_t, if_f] })))
     }),
     state,
@@ -544,34 +583,42 @@ pub fn parse_if_sugar(state: parser::State) -> parser::Answer<Option<Box<Term>>>
 }
 
 pub fn parse_bng(state: parser::State) -> parser::Answer<Option<Box<Term>>> {
-  return parser::guard(parser::text_parser("!"), Box::new(|state| {
-    let (state, _)    = parser::consume("!", state)?;
-    let (state, term) = parse_term(state)?;
-    Ok((state, term))
-  }), state);
+  return parser::guard(
+    parser::text_parser("!"),
+    Box::new(|state| {
+      let (state, _) = parser::consume("!", state)?;
+      let (state, term) = parse_term(state)?;
+      Ok((state, term))
+    }),
+    state,
+  );
 }
 
 pub fn parse_term(state: parser::State) -> parser::Answer<Box<Term>> {
-  parser::grammar("Term", &[
-    Box::new(parse_let),
-    Box::new(parse_dup),
-    Box::new(parse_lam),
-    Box::new(parse_ctr),
-    Box::new(parse_op2),
-    Box::new(parse_app),
-    Box::new(parse_sup),
-    Box::new(parse_num),
-    Box::new(parse_sym_sugar),
-    Box::new(parse_chr_sugar),
-    Box::new(parse_str_sugar),
-    Box::new(parse_lst_sugar),
-    Box::new(parse_if_sugar),
-    Box::new(parse_bng),
-    Box::new(parse_ask_sugar_named),
-    Box::new(parse_ask_sugar_anon),
-    Box::new(parse_var),
-    Box::new(|state| Ok((state, None))),
-  ], state)
+  parser::grammar(
+    "Term",
+    &[
+      Box::new(parse_let),
+      Box::new(parse_dup),
+      Box::new(parse_lam),
+      Box::new(parse_ctr),
+      Box::new(parse_op2),
+      Box::new(parse_app),
+      Box::new(parse_sup),
+      Box::new(parse_num),
+      Box::new(parse_sym_sugar),
+      Box::new(parse_chr_sugar),
+      Box::new(parse_str_sugar),
+      Box::new(parse_lst_sugar),
+      Box::new(parse_if_sugar),
+      Box::new(parse_bng),
+      Box::new(parse_ask_sugar_named),
+      Box::new(parse_ask_sugar_anon),
+      Box::new(parse_var),
+      Box::new(|state| Ok((state, None))),
+    ],
+    state,
+  )
 }
 
 pub fn parse_rule(state: parser::State) -> parser::Answer<Option<Rule>> {
@@ -590,7 +637,7 @@ pub fn parse_rule(state: parser::State) -> parser::Answer<Option<Rule>> {
 pub fn parse_smap(state: parser::State) -> parser::Answer<Option<SMap>> {
   pub fn parse_stct(state: parser::State) -> parser::Answer<bool> {
     let (state, stct) = parser::text("!", state)?;
-    let (state, _)    = parse_term(state)?;
+    let (state, _) = parse_term(state)?;
     Ok((state, stct))
   }
   let (state, init) = parser::text("(", state)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(atomic_from_mut)]
 #![feature(atomic_mut_ptr)]
-
 #![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(non_snake_case)]
@@ -12,475 +11,461 @@
 pub mod language;
 pub mod runtime;
 
-pub use language::{*};
-pub use runtime::{*};
+pub use language::*;
+pub use runtime::*;
 
-pub use runtime::{Ptr,
-  DP0, DP1, VAR, ARG,
-  ERA, LAM, APP, SUP,
-  CTR, FUN, OP2, U60, F60,
-  ADD, SUB, MUL, DIV,
-  MOD, AND, OR , XOR,
-  SHL, SHR, LTN, LTE,
-  EQL, GTE, GTN, NEQ,
-  get_tag,
-  get_ext,
-  get_val,
-  get_num,
-  get_loc,
-  CELLS_PER_KB,
-  CELLS_PER_MB,
-  CELLS_PER_GB,
+pub use runtime::{
+  get_ext, get_loc, get_num, get_tag, get_val, Ptr, ADD, AND, APP, ARG, CELLS_PER_GB, CELLS_PER_KB,
+  CELLS_PER_MB, CTR, DIV, DP0, DP1, EQL, ERA, F60, FUN, GTE, GTN, LAM, LTE, LTN, MOD, MUL, NEQ,
+  OP2, OR, SHL, SHR, SUB, SUP, U60, VAR, XOR,
 };
 
 pub use language::syntax::{
   Term,
-  Term::Var, // TODO: add `global: bool`
-  Term::Dup,
-  Term::Let,
-  Term::Lam,
   Term::App,
   Term::Ctr,
-  Term::U6O,
-  Term::F6O,
+  Term::Dup,
+  Term::Lam,
+  Term::Let,
   Term::Op2,
+  Term::Var, // TODO: add `global: bool`
+  Term::F6O,
+  Term::U6O,
 };
 
 //// Helps with WASM debugging
 //macro_rules! log {
-  //( $( $t:tt )* ) => {
-    //web_sys::console::log_1(&format!( $( $t )* ).into());
-  //}
+//( $( $t:tt )* ) => {
+//web_sys::console::log_1(&format!( $( $t )* ).into());
+//}
 //}
 
 //#[wasm_bindgen]
 //pub fn make_call(func: &str, args: &[&str]) -> Result<language::syntax::Term, String> {
-  //// TODO: redundant with `make_main_call`
-  //let args = args.iter().map(|par| language::syntax::read_term(par).unwrap()).collect();
-  //let name = func.to_string();
-  //Ok(language::syntax::Term::Ctr { name, args })
+//// TODO: redundant with `make_main_call`
+//let args = args.iter().map(|par| language::syntax::read_term(par).unwrap()).collect();
+//let name = func.to_string();
+//Ok(language::syntax::Term::Ctr { name, args })
 //}
 
 ////#[cfg(test)]
 ////mod tests {
-  ////use crate::eval_code;
-  ////use crate::make_call;
+////use crate::eval_code;
+////use crate::make_call;
 
-  ////#[test]
-  ////fn test() {
-    ////let code = "
-    ////(Fn 0) = 0
-    ////(Fn 1) = 1
-    ////(Fn n) = (+ (Fn (- n 1)) (Fn (- n 2)))
-    ////(Main) = (Fn 20)
-    ////";
+////#[test]
+////fn test() {
+////let code = "
+////(Fn 0) = 0
+////(Fn 1) = 1
+////(Fn n) = (+ (Fn (- n 1)) (Fn (- n 2)))
+////(Main) = (Fn 20)
+////";
 
-    ////let (norm, _cost, _size, _time) = eval_code(&make_call("Main", &[]).unwrap(), code, false, 4 << 30).unwrap();
-    ////assert_eq!(norm, "6765");
-  ////}
+////let (norm, _cost, _size, _time) = eval_code(&make_call("Main", &[]).unwrap(), code, false, 4 << 30).unwrap();
+////assert_eq!(norm, "6765");
+////}
 ////}
 
 //#[wasm_bindgen]
 //#[derive(Clone, Debug)]
 //pub struct Reduced {
-  //norm: String,
-  //cost: u64,
-  //size: u64,
-  //time: u64,
+//norm: String,
+//cost: u64,
+//size: u64,
+//time: u64,
 //}
 
 //#[wasm_bindgen]
 //impl Reduced {
-  //pub fn get_norm(&self) -> String {
-    //return self.norm.clone();
-  //}
+//pub fn get_norm(&self) -> String {
+//return self.norm.clone();
+//}
 
-  //pub fn get_cost(&self) -> u64 {
-    //return self.cost;
-  //}
+//pub fn get_cost(&self) -> u64 {
+//return self.cost;
+//}
 
-  //pub fn get_size(&self) -> u64 {
-    //return self.size;
-  //}
+//pub fn get_size(&self) -> u64 {
+//return self.size;
+//}
 
-  //pub fn get_time(&self) -> u64 {
-    //return self.time;
-  //}
+//pub fn get_time(&self) -> u64 {
+//return self.time;
+//}
 //}
 
 //#[wasm_bindgen]
 //impl Runtime {
 
-  ///// Creates a new, empty runtime
-  //pub fn new(size: usize) -> Runtime {
-    //Runtime {
-      //heap: runtime::new_heap(size, runtime::available_parallelism()),
-      //prog: runtime::new_program(),
-      //book: language::rulebook::new_rulebook(),
-    //}
-  //}
-
-  ///// Creates a runtime from source code, given a max number of nodes
-  //pub fn from_code_with_size(code: &str, size: usize) -> Result<Runtime, String> {
-    //let file = language::syntax::read_file(code)?;
-    //let heap = runtime::new_heap(size, runtime::available_parallelism());
-    //let prog = runtime::new_program();
-    //let book = language::rulebook::gen_rulebook(&file);
-    //return Ok(Runtime { heap, prog, book });
-  //}
-
-  ////fn get_area(&mut self) -> runtime::Area {
-    ////return runtime::get_area(&mut self.heap, 0)
-  ////}
-
-  ///// Creates a runtime from a source code
-  //#[cfg(not(target_arch = "wasm32"))]
-  //pub fn from_code(code: &str) -> Result<Runtime, String> {
-    //Runtime::from_code_with_size(code, 4 * CELLS_PER_GB)
-  //}
-
-  //#[cfg(target_arch = "wasm32")]
-  //pub fn from_code(code: &str) -> Result<Runtime, String> {
-    //Runtime::from_code_with_size(code, 256 * CELLS_PER_MB)
-  //}
-
-  ///// Extends a runtime with new definitions
-  //pub fn define(&mut self, _code: &str) {
-    //todo!()
-  //}
-
-  ///// Allocates a new term, returns its location
-  //pub fn alloc_code(&mut self, code: &str) -> Result<u64, String> {
-    //Ok(self.alloc_term(&*language::syntax::read_term(code)?))
-  //}
-
-  ///// Given a location, returns the pointer stored on it
-  //pub fn load_ptr(&self, host: u64) -> Ptr {
-    //runtime::load_ptr(&self.heap, host)
-  //}
-
-  ///// Given a location, evaluates a term to head normal form
-  //pub fn reduce(&mut self, host: u64) {
-    //runtime::reduce(&self.heap, &self.prog, &[0], host); // FIXME: add parallelism
-  //}
-
-  ///// Given a location, evaluates a term to full normal form
-  //pub fn normalize(&mut self, host: u64) {
-    //runtime::normalize(&self.heap, &self.prog, &[0], host, false);
-  //}
-
-  ///// Evaluates a code, allocs and evaluates to full normal form. Returns its location.
-  //pub fn normalize_code(&mut self, code: &str) -> u64 {
-    //let host = self.alloc_code(code).ok().unwrap();
-    //self.normalize(host);
-    //return host;
-  //}
-
-  ///// Evaluates a code to normal form. Returns its location.
-  //pub fn eval_to_loc(&mut self, code: &str) -> u64 {
-    //return self.normalize_code(code);
-  //}
-
-  ///// Evaluates a code to normal form.
-  //pub fn eval(&mut self, code: &str) -> String {
-    //let host = self.normalize_code(code);
-    //return self.show(host);
-  //}
-
-  //// /// Given a location, runs side-effective actions
-  ////#[cfg(not(target_arch = "wasm32"))]
-  ////pub fn run_io(&mut self, host: u64) {
-    ////runtime::run_io(&mut self.heap, &self.prog, &[0], host)
-  ////}
-
-  ///// Given a location, recovers the lambda Term stored on it, as code
-  //pub fn show(&self, host: u64) -> String {
-    //language::readback::as_code(&self.heap, &self.prog, host)
-  //}
-
-  ///// Given a location, recovers the linear Term stored on it, as code
-  //pub fn show_linear(&self, host: u64) -> String {
-    //language::readback::as_linear_code(&self.heap, &self.prog, host)
-  //}
-
-  ///// Return the total number of graph rewrites computed
-  //pub fn get_rewrites(&self) -> u64 {
-    //runtime::get_cost(&self.heap)
-  //}
-
-  ///// Returns the name of a given id
-  //pub fn get_name(&self, id: u64) -> String {
-    //self.book.id_to_name.get(&id).unwrap_or(&"?".to_string()).clone()
-  //}
-
-  ///// Returns the arity of a given id
-  //pub fn get_arity(&self, id: u64) -> u64 {
-    //*self.book.id_to_arit.get(&id).unwrap_or(&u64::MAX)
-  //}
-
-  ///// Returns the name of a given id
-  //pub fn get_id(&self, name: &str) -> u64 {
-    //*self.book.name_to_id.get(name).unwrap_or(&u64::MAX)
-  //}
-
-  //// WASM re-exports
-  
-  //pub fn DP0() -> u64 {
-    //return DP0;
-  //}
-
-  //pub fn DP1() -> u64 {
-    //return DP1;
-  //}
-
-  //pub fn VAR() -> u64 {
-    //return VAR;
-  //}
-
-  //pub fn ARG() -> u64 {
-    //return ARG;
-  //}
-
-  //pub fn ERA() -> u64 {
-    //return ERA;
-  //}
-
-  //pub fn LAM() -> u64 {
-    //return LAM;
-  //}
-
-  //pub fn APP() -> u64 {
-    //return APP;
-  //}
-
-  //pub fn SUP() -> u64 {
-    //return SUP;
-  //}
-
-  //pub fn CTR() -> u64 {
-    //return CTR;
-  //}
-
-  //pub fn FUN() -> u64 {
-    //return FUN;
-  //}
-
-  //pub fn OP2() -> u64 {
-    //return OP2;
-  //}
-
-  //pub fn NUM() -> u64 {
-    //return NUM;
-  //}
-
-  //pub fn ADD() -> u64 {
-    //return ADD;
-  //}
-
-  //pub fn SUB() -> u64 {
-    //return SUB;
-  //}
-
-  //pub fn MUL() -> u64 {
-    //return MUL;
-  //}
-
-  //pub fn DIV() -> u64 {
-    //return DIV;
-  //}
-
-  //pub fn MOD() -> u64 {
-    //return MOD;
-  //}
-
-  //pub fn AND() -> u64 {
-    //return AND;
-  //}
-
-  //pub fn OR() -> u64 {
-    //return OR;
-  //}
-
-  //pub fn XOR() -> u64 {
-    //return XOR;
-  //}
-
-  //pub fn SHL() -> u64 {
-    //return SHL;
-  //}
-
-  //pub fn SHR() -> u64 {
-    //return SHR;
-  //}
-
-  //pub fn LTN() -> u64 {
-    //return LTN;
-  //}
-
-  //pub fn LTE() -> u64 {
-    //return LTE;
-  //}
-
-  //pub fn EQL() -> u64 {
-    //return EQL;
-  //}
-
-  //pub fn GTE() -> u64 {
-    //return GTE;
-  //}
-
-  //pub fn GTN() -> u64 {
-    //return GTN;
-  //}
-
-  //pub fn NEQ() -> u64 {
-    //return NEQ;
-  //}
-
-  //pub fn CELLS_PER_KB() -> usize {
-    //return CELLS_PER_KB;
-  //}
-
-  //pub fn CELLS_PER_MB() -> usize {
-    //return CELLS_PER_MB; 
-  //}
-
-  //pub fn CELLS_PER_GB() -> usize {
-    //return CELLS_PER_GB; 
-  //}
-
-  //pub fn get_tag(lnk: Ptr) -> u64 {
-    //return get_tag(lnk);
-  //}
-
-  //pub fn get_ext(lnk: Ptr) -> u64 {
-    //return get_ext(lnk);
-  //}
-
-  //pub fn get_val(lnk: Ptr) -> u64 {
-    //return get_val(lnk);
-  //}
-
-  //pub fn get_num(lnk: Ptr) -> u64 {
-    //return get_num(lnk);
-  //}
-
-  //pub fn get_loc(lnk: Ptr, arg: u64) -> u64 {
-    //return get_loc(lnk, arg);
-  //}
-
-  //pub fn Var(pos: u64) -> Ptr {
-    //return runtime::Var(pos);
-  //}
-
-  //pub fn Dp0(col: u64, pos: u64) -> Ptr {
-    //return runtime::Dp0(col, pos);
-  //}
-
-  //pub fn Dp1(col: u64, pos: u64) -> Ptr {
-    //return runtime::Dp1(col, pos);
-  //}
-
-  //pub fn Arg(pos: u64) -> Ptr {
-    //return runtime::Arg(pos);
-  //}
-
-  //pub fn Era() -> Ptr {
-    //return runtime::Era();
-  //}
-
-  //pub fn Lam(pos: u64) -> Ptr {
-    //return runtime::Lam(pos);
-  //}
-
-  //pub fn App(pos: u64) -> Ptr {
-    //return runtime::App(pos);
-  //}
-
-  //pub fn Sup(col: u64, pos: u64) -> Ptr {
-    //return runtime::Sup(col, pos);
-  //}
-
-  //pub fn Op2(ope: u64, pos: u64) -> Ptr {
-    //return runtime::Op2(ope, pos);
-  //}
-
-  //pub fn Num(val: u64) -> Ptr {
-    //return runtime::Num(val);
-  //}
-
-  //pub fn Ctr(fun: u64, pos: u64) -> Ptr {
-    //return runtime::Ctr(fun, pos);
-  //}
-
-  //pub fn Fun(fun: u64, pos: u64) -> Ptr {
-    //return runtime::Fun(fun, pos);
-  //}
-
-  //pub fn link(&mut self, loc: u64, lnk: Ptr) -> Ptr {
-    //return runtime::link(&self.heap, loc, lnk);
-  //}
-
-  //pub fn alloc(&mut self, size: u64) -> u64 {
-    //return runtime::alloc(&self.heap, 0, size); // FIXME tid?
-  //}
-
-  //pub fn free(&mut self, loc: u64, size: u64) {
-    //return runtime::free(&self.heap, 0, loc, size); // FIXME tid?
-  //}
-
-  //pub fn collect(&mut self, term: Ptr) {
-    //return runtime::collect(&self.heap, &self.prog.arit, 0, term); // FIXME tid?
-  //}
+///// Creates a new, empty runtime
+//pub fn new(size: usize) -> Runtime {
+//Runtime {
+//heap: runtime::new_heap(size, runtime::available_parallelism()),
+//prog: runtime::new_program(),
+//book: language::rulebook::new_rulebook(),
+//}
+//}
+
+///// Creates a runtime from source code, given a max number of nodes
+//pub fn from_code_with_size(code: &str, size: usize) -> Result<Runtime, String> {
+//let file = language::syntax::read_file(code)?;
+//let heap = runtime::new_heap(size, runtime::available_parallelism());
+//let prog = runtime::new_program();
+//let book = language::rulebook::gen_rulebook(&file);
+//return Ok(Runtime { heap, prog, book });
+//}
+
+////fn get_area(&mut self) -> runtime::Area {
+////return runtime::get_area(&mut self.heap, 0)
+////}
+
+///// Creates a runtime from a source code
+//#[cfg(not(target_arch = "wasm32"))]
+//pub fn from_code(code: &str) -> Result<Runtime, String> {
+//Runtime::from_code_with_size(code, 4 * CELLS_PER_GB)
+//}
+
+//#[cfg(target_arch = "wasm32")]
+//pub fn from_code(code: &str) -> Result<Runtime, String> {
+//Runtime::from_code_with_size(code, 256 * CELLS_PER_MB)
+//}
+
+///// Extends a runtime with new definitions
+//pub fn define(&mut self, _code: &str) {
+//todo!()
+//}
+
+///// Allocates a new term, returns its location
+//pub fn alloc_code(&mut self, code: &str) -> Result<u64, String> {
+//Ok(self.alloc_term(&*language::syntax::read_term(code)?))
+//}
+
+///// Given a location, returns the pointer stored on it
+//pub fn load_ptr(&self, host: u64) -> Ptr {
+//runtime::load_ptr(&self.heap, host)
+//}
+
+///// Given a location, evaluates a term to head normal form
+//pub fn reduce(&mut self, host: u64) {
+//runtime::reduce(&self.heap, &self.prog, &[0], host); // FIXME: add parallelism
+//}
+
+///// Given a location, evaluates a term to full normal form
+//pub fn normalize(&mut self, host: u64) {
+//runtime::normalize(&self.heap, &self.prog, &[0], host, false);
+//}
+
+///// Evaluates a code, allocs and evaluates to full normal form. Returns its location.
+//pub fn normalize_code(&mut self, code: &str) -> u64 {
+//let host = self.alloc_code(code).ok().unwrap();
+//self.normalize(host);
+//return host;
+//}
+
+///// Evaluates a code to normal form. Returns its location.
+//pub fn eval_to_loc(&mut self, code: &str) -> u64 {
+//return self.normalize_code(code);
+//}
+
+///// Evaluates a code to normal form.
+//pub fn eval(&mut self, code: &str) -> String {
+//let host = self.normalize_code(code);
+//return self.show(host);
+//}
+
+//// /// Given a location, runs side-effective actions
+////#[cfg(not(target_arch = "wasm32"))]
+////pub fn run_io(&mut self, host: u64) {
+////runtime::run_io(&mut self.heap, &self.prog, &[0], host)
+////}
+
+///// Given a location, recovers the lambda Term stored on it, as code
+//pub fn show(&self, host: u64) -> String {
+//language::readback::as_code(&self.heap, &self.prog, host)
+//}
+
+///// Given a location, recovers the linear Term stored on it, as code
+//pub fn show_linear(&self, host: u64) -> String {
+//language::readback::as_linear_code(&self.heap, &self.prog, host)
+//}
+
+///// Return the total number of graph rewrites computed
+//pub fn get_rewrites(&self) -> u64 {
+//runtime::get_cost(&self.heap)
+//}
+
+///// Returns the name of a given id
+//pub fn get_name(&self, id: u64) -> String {
+//self.book.id_to_name.get(&id).unwrap_or(&"?".to_string()).clone()
+//}
+
+///// Returns the arity of a given id
+//pub fn get_arity(&self, id: u64) -> u64 {
+//*self.book.id_to_arit.get(&id).unwrap_or(&u64::MAX)
+//}
+
+///// Returns the name of a given id
+//pub fn get_id(&self, name: &str) -> u64 {
+//*self.book.name_to_id.get(name).unwrap_or(&u64::MAX)
+//}
+
+//// WASM re-exports
+
+//pub fn DP0() -> u64 {
+//return DP0;
+//}
+
+//pub fn DP1() -> u64 {
+//return DP1;
+//}
+
+//pub fn VAR() -> u64 {
+//return VAR;
+//}
+
+//pub fn ARG() -> u64 {
+//return ARG;
+//}
+
+//pub fn ERA() -> u64 {
+//return ERA;
+//}
+
+//pub fn LAM() -> u64 {
+//return LAM;
+//}
+
+//pub fn APP() -> u64 {
+//return APP;
+//}
+
+//pub fn SUP() -> u64 {
+//return SUP;
+//}
+
+//pub fn CTR() -> u64 {
+//return CTR;
+//}
+
+//pub fn FUN() -> u64 {
+//return FUN;
+//}
+
+//pub fn OP2() -> u64 {
+//return OP2;
+//}
+
+//pub fn NUM() -> u64 {
+//return NUM;
+//}
+
+//pub fn ADD() -> u64 {
+//return ADD;
+//}
+
+//pub fn SUB() -> u64 {
+//return SUB;
+//}
+
+//pub fn MUL() -> u64 {
+//return MUL;
+//}
+
+//pub fn DIV() -> u64 {
+//return DIV;
+//}
+
+//pub fn MOD() -> u64 {
+//return MOD;
+//}
+
+//pub fn AND() -> u64 {
+//return AND;
+//}
+
+//pub fn OR() -> u64 {
+//return OR;
+//}
+
+//pub fn XOR() -> u64 {
+//return XOR;
+//}
+
+//pub fn SHL() -> u64 {
+//return SHL;
+//}
+
+//pub fn SHR() -> u64 {
+//return SHR;
+//}
+
+//pub fn LTN() -> u64 {
+//return LTN;
+//}
+
+//pub fn LTE() -> u64 {
+//return LTE;
+//}
+
+//pub fn EQL() -> u64 {
+//return EQL;
+//}
+
+//pub fn GTE() -> u64 {
+//return GTE;
+//}
+
+//pub fn GTN() -> u64 {
+//return GTN;
+//}
+
+//pub fn NEQ() -> u64 {
+//return NEQ;
+//}
+
+//pub fn CELLS_PER_KB() -> usize {
+//return CELLS_PER_KB;
+//}
+
+//pub fn CELLS_PER_MB() -> usize {
+//return CELLS_PER_MB;
+//}
+
+//pub fn CELLS_PER_GB() -> usize {
+//return CELLS_PER_GB;
+//}
+
+//pub fn get_tag(lnk: Ptr) -> u64 {
+//return get_tag(lnk);
+//}
+
+//pub fn get_ext(lnk: Ptr) -> u64 {
+//return get_ext(lnk);
+//}
+
+//pub fn get_val(lnk: Ptr) -> u64 {
+//return get_val(lnk);
+//}
+
+//pub fn get_num(lnk: Ptr) -> u64 {
+//return get_num(lnk);
+//}
+
+//pub fn get_loc(lnk: Ptr, arg: u64) -> u64 {
+//return get_loc(lnk, arg);
+//}
+
+//pub fn Var(pos: u64) -> Ptr {
+//return runtime::Var(pos);
+//}
+
+//pub fn Dp0(col: u64, pos: u64) -> Ptr {
+//return runtime::Dp0(col, pos);
+//}
+
+//pub fn Dp1(col: u64, pos: u64) -> Ptr {
+//return runtime::Dp1(col, pos);
+//}
+
+//pub fn Arg(pos: u64) -> Ptr {
+//return runtime::Arg(pos);
+//}
+
+//pub fn Era() -> Ptr {
+//return runtime::Era();
+//}
+
+//pub fn Lam(pos: u64) -> Ptr {
+//return runtime::Lam(pos);
+//}
+
+//pub fn App(pos: u64) -> Ptr {
+//return runtime::App(pos);
+//}
+
+//pub fn Sup(col: u64, pos: u64) -> Ptr {
+//return runtime::Sup(col, pos);
+//}
+
+//pub fn Op2(ope: u64, pos: u64) -> Ptr {
+//return runtime::Op2(ope, pos);
+//}
+
+//pub fn Num(val: u64) -> Ptr {
+//return runtime::Num(val);
+//}
+
+//pub fn Ctr(fun: u64, pos: u64) -> Ptr {
+//return runtime::Ctr(fun, pos);
+//}
+
+//pub fn Fun(fun: u64, pos: u64) -> Ptr {
+//return runtime::Fun(fun, pos);
+//}
+
+//pub fn link(&mut self, loc: u64, lnk: Ptr) -> Ptr {
+//return runtime::link(&self.heap, loc, lnk);
+//}
+
+//pub fn alloc(&mut self, size: u64) -> u64 {
+//return runtime::alloc(&self.heap, 0, size); // FIXME tid?
+//}
+
+//pub fn free(&mut self, loc: u64, size: u64) {
+//return runtime::free(&self.heap, 0, loc, size); // FIXME tid?
+//}
+
+//pub fn collect(&mut self, term: Ptr) {
+//return runtime::collect(&self.heap, &self.prog.arit, 0, term); // FIXME tid?
+//}
 
 //}
 
 // Methods that aren't compiled to JS
 //impl Runtime {
-  ///// Allocates a new term, returns its location
-  //pub fn alloc_term(&mut self, term: &language::syntax::Term) -> u64 {
-    //runtime::alloc_term(&self.heap, 0, &self.book, term) // FIXME tid?
-  //}
+///// Allocates a new term, returns its location
+//pub fn alloc_term(&mut self, term: &language::syntax::Term) -> u64 {
+//runtime::alloc_term(&self.heap, 0, &self.book, term) // FIXME tid?
+//}
 
-  ///// Given a location, recovers the Term stored on it
-  //pub fn readback(&self, host: u64) -> Box<Term> {
-    //language::readback::as_term(&self.heap, &self.prog, host)
-  //}
+///// Given a location, recovers the Term stored on it
+//pub fn readback(&self, host: u64) -> Box<Term> {
+//language::readback::as_term(&self.heap, &self.prog, host)
+//}
 
-  ///// Given a location, recovers the Term stored on it
-  //pub fn linear_readback(&self, host: u64) -> Box<Term> {
-    //language::readback::as_linear_term(&self.heap, &self.prog, host)
-  //}
+///// Given a location, recovers the Term stored on it
+//pub fn linear_readback(&self, host: u64) -> Box<Term> {
+//language::readback::as_linear_term(&self.heap, &self.prog, host)
+//}
 //}
 
 //pub fn example() -> Result<(), String> {
-  //let mut rt = Runtime::from_code_with_size("
-    //(Double Zero)     = Zero
-    //(Double (Succ x)) = (Succ (Succ (Double x)))
-  //", 10000).unwrap();
-  //let loc = rt.normalize_code("(Double (Succ (Succ Zero)))");
-  //println!("{}", rt.show(loc));
-  //return Ok(());
+//let mut rt = Runtime::from_code_with_size("
+//(Double Zero)     = Zero
+//(Double (Succ x)) = (Succ (Succ (Double x)))
+//", 10000).unwrap();
+//let loc = rt.normalize_code("(Double (Succ (Succ Zero)))");
+//println!("{}", rt.show(loc));
+//return Ok(());
 //}
 
 ////#[cfg(test)]
 ////mod tests {
-  ////use crate::eval_code;
-  ////use crate::make_call;
+////use crate::eval_code;
+////use crate::make_call;
 
-  ////#[test]
-  ////fn test() {
-    ////let code = "
-    ////(Fn 0) = 0
-    ////(Fn 1) = 1
-    ////(Fn n) = (+ (Fn (- n 1)) (Fn (- n 2)))
-    ////(Main) = (Fn 20)
-    ////";
+////#[test]
+////fn test() {
+////let code = "
+////(Fn 0) = 0
+////(Fn 1) = 1
+////(Fn n) = (+ (Fn (- n 1)) (Fn (- n 2)))
+////(Main) = (Fn 20)
+////";
 
-    ////let (norm, _cost, _size, _time) = language::rulebook::eval_code(&make_call("Main", &[]).unwrap(), code, false, 32 << 20).unwrap();
-    ////assert_eq!(norm, "6765");
-  ////}
+////let (norm, _cost, _size, _time) = language::rulebook::eval_code(&make_call("Main", &[]).unwrap(), code, false, 32 << 20).unwrap();
+////assert_eq!(norm, "6765");
+////}
 ////}
 ////
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(atomic_from_mut)]
-#![feature(atomic_mut_ptr)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(non_snake_case)]
@@ -7,6 +5,8 @@
 #![allow(unused_parens)]
 #![allow(unused_labels)]
 #![allow(non_upper_case_globals)]
+
+pub mod polyfills;
 
 pub mod language;
 pub mod runtime;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #![feature(atomic_from_mut)]
 #![feature(atomic_mut_ptr)]
-
 #![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(non_snake_case)]
@@ -9,10 +8,10 @@
 #![allow(unused_labels)]
 #![allow(non_upper_case_globals)]
 
+mod api;
+mod compiler;
 mod language;
 mod runtime;
-mod compiler;
-mod api;
 
 use clap::{Parser, Subcommand};
 
@@ -28,8 +27,7 @@ struct Cli {
 enum Command {
   /// Load a file and run an expression
   #[clap(aliases = &["r"])]
-
-  Run { 
+  Run {
     /// Set the heap size (in 64-bit nodes).
     #[clap(short = 's', long, default_value = "auto", parse(try_from_str=parse_size))]
     size: usize,
@@ -59,7 +57,7 @@ enum Command {
   #[clap(aliases = &["c"])]
   Compile {
     /// A "file.hvm" to load.
-    file: String
+    file: String,
   },
 }
 
@@ -80,7 +78,12 @@ fn run_cli() -> Result<(), String> {
       println!("{}", norm);
       if show_cost {
         eprintln!();
-        eprintln!("\x1b[32m[TIME: {:.2}s | COST: {} | RPS: {:.2}m]\x1b[0m", ((time as f64)/1000.0), cost - 1, (cost as f64) / (time as f64) / 1000.0);
+        eprintln!(
+          "\x1b[32m[TIME: {:.2}s | COST: {} | RPS: {:.2}m]\x1b[0m",
+          ((time as f64) / 1000.0),
+          cost - 1,
+          (cost as f64) / (time as f64) / 1000.0
+        );
       }
       Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(atomic_from_mut)]
-#![feature(atomic_mut_ptr)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(non_snake_case)]
@@ -11,6 +9,7 @@
 mod api;
 mod compiler;
 mod language;
+mod polyfills;
 mod runtime;
 
 use clap::{Parser, Subcommand};

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ enum Command {
 
 fn main() {
   if let Err(err) = run_cli() {
-    eprintln!("{}", err);
+    eprintln!("{err}");
     std::process::exit(1);
   };
 }
@@ -75,7 +75,7 @@ fn run_cli() -> Result<(), String> {
     Command::Run { size, tids, cost: show_cost, debug, file, expr } => {
       let tids = if debug { 1 } else { tids };
       let (norm, cost, time) = api::eval(&load_code(&file)?, &expr, Vec::new(), size, tids, debug)?;
-      println!("{}", norm);
+      println!("{norm}");
       if show_cost {
         eprintln!();
         eprintln!(
@@ -91,7 +91,7 @@ fn run_cli() -> Result<(), String> {
       let code = load_code(&file)?;
       let name = file.replace(".hvm", "");
       compiler::compile(&code, &name).map_err(|x| x.to_string())?;
-      println!("Compiled definitions to '/{}'.", name);
+      println!("Compiled definitions to '/{name}'.");
       Ok(())
     }
   }
@@ -99,28 +99,28 @@ fn run_cli() -> Result<(), String> {
 
 fn parse_size(text: &str) -> Result<usize, String> {
   if text == "auto" {
-    return Ok(runtime::default_heap_size());
+    Ok(runtime::default_heap_size())
   } else {
-    return text.parse::<usize>().map_err(|x| format!("{}", x));
+    text.parse::<usize>().map_err(|x| format!("{x}"))
   }
 }
 
 fn parse_tids(text: &str) -> Result<usize, String> {
   if text == "auto" {
-    return Ok(runtime::default_heap_tids());
+    Ok(runtime::default_heap_tids())
   } else {
-    return text.parse::<usize>().map_err(|x| format!("{}", x));
+    text.parse::<usize>().map_err(|x| format!("{x}"))
   }
 }
 
 fn parse_bool(text: &str) -> Result<bool, String> {
-  return text.parse::<bool>().map_err(|x| format!("{}", x));
+  text.parse::<bool>().map_err(|x| format!("{x}"))
 }
 
 fn load_code(file: &str) -> Result<String, String> {
   if file.is_empty() {
-    return Ok(String::new());
+    Ok(String::new())
   } else {
-    return std::fs::read_to_string(file).map_err(|err| err.to_string());
+    std::fs::read_to_string(file).map_err(|err| err.to_string())
   }
 }

--- a/src/polyfills.rs
+++ b/src/polyfills.rs
@@ -1,0 +1,70 @@
+//! This module contains functions that act as a polyfill for unstable standard library functions
+//! that we use in this crate. As these features become stabilized, we should remove these functions
+//! and use the standard library implementations.
+
+use std::{
+  cell::UnsafeCell,
+  sync::atomic::{AtomicU64, AtomicU8},
+};
+
+pub trait PolyfillAtomicFromMutSlice: Sized {
+  type Int;
+  fn polyfill_from_mut_slice(v: &mut [Self::Int]) -> &mut [Self];
+}
+
+pub trait PolyfillAtomicAsMutPtr {
+  type Int;
+  fn polyfill_as_mut_ptr(&self) -> *mut Self::Int;
+}
+
+impl PolyfillAtomicAsMutPtr for AtomicU8 {
+  type Int = u8;
+
+  fn polyfill_as_mut_ptr(&self) -> *mut Self::Int {
+    unsafe { (*(self as *const Self as *const UnsafeCell<Self::Int>)).get() }
+  }
+}
+
+impl PolyfillAtomicAsMutPtr for AtomicU64 {
+  type Int = u64;
+
+  fn polyfill_as_mut_ptr(&self) -> *mut Self::Int {
+    unsafe { (*(self as *const Self as *const UnsafeCell<Self::Int>)).get() }
+  }
+}
+
+#[cfg(
+// Here we reference a custom cfg check to avoid the nightly `target_has_atomic_equal_alignment`
+// cfg. The logic for supported platforms is implemented in `build.rs`
+stable_target_has_atomic_equal_alignment
+  )]
+impl PolyfillAtomicFromMutSlice for AtomicU8 {
+  type Int = u8;
+
+  fn polyfill_from_mut_slice(v: &mut [u8]) -> &mut [Self] {
+    use std::mem::align_of;
+    let [] = [(); align_of::<Self>() - align_of::<u8>()];
+    // SAFETY:
+    //  - the mutable reference guarantees unique ownership.
+    //  - the alignment of u8 and AtomicU8 is equal, according to our cfg check above.
+    unsafe { &mut *(v as *mut [u8] as *mut [AtomicU8]) }
+  }
+}
+
+#[cfg(
+// Here we reference a custom cfg check to avoid the nightly `target_has_atomic_equal_alignment`
+// cfg. The logic for supported platforms is implemented in `build.rs`
+stable_target_has_atomic_equal_alignment
+  )]
+impl PolyfillAtomicFromMutSlice for AtomicU64 {
+  type Int = u64;
+
+  fn polyfill_from_mut_slice(v: &mut [u64]) -> &mut [Self] {
+    use std::mem::align_of;
+    let [] = [(); align_of::<Self>() - align_of::<u64>()];
+    // SAFETY:
+    //  - the mutable reference guarantees unique ownership.
+    //  - the alignment of u8 and AtomicU8 is equal, according to our cfg check above.
+    unsafe { &mut *(v as *mut [u64] as *mut [AtomicU64]) }
+  }
+}

--- a/src/runtime/base/debug.rs
+++ b/src/runtime/base/debug.rs
@@ -116,11 +116,10 @@ pub fn show_at(heap: &Heap, prog: &Program, host: u64, tlocs: &[AtomicU64]) -> S
     tlocs: &[AtomicU64],
   ) -> String {
     let term = load_ptr(heap, host);
-    let done;
-    if term == 0 {
-      done = "<>".to_string();
+    let done = if term == 0 {
+      "<>".to_string()
     } else {
-      done = match get_tag(term) {
+      match get_tag(term) {
         DP0 => {
           if let Some(name) = names.get(&get_loc(term, 0)) {
             format!("a{name}")
@@ -198,8 +197,9 @@ pub fn show_at(heap: &Heap, prog: &Program, host: u64, tlocs: &[AtomicU64]) -> S
         }
         ERA => "*".to_string(),
         _ => format!("<era:{}>", get_tag(term)),
-      };
-    }
+      }
+    };
+
     for (tid, tid_loc) in tlocs.iter().enumerate() {
       if host == tid_loc.load(Ordering::Relaxed) {
         return format!("<{tid}>{done}");

--- a/src/runtime/base/memory.rs
+++ b/src/runtime/base/memory.rs
@@ -1,23 +1,23 @@
 // HVM's memory model
 // ------------------
-// 
+//
 // The runtime memory consists of just a vector of u64 pointers. That is:
 //
 //   Mem ::= Vec<Ptr>
-// 
+//
 // A pointer has 3 parts:
 //
 //   Ptr ::= 0xTAAAAAAABBBBBBBB
 //
 // Where:
 //
-//   T : u4  is the pointer tag 
+//   T : u4  is the pointer tag
 //   A : u28 is the 1st value
 //   B : u32 is the 2nd value
 //
 // There are 12 possible tags:
 //
-//   Tag | Val | Meaning  
+//   Tag | Val | Meaning
 //   ----| --- | -------------------------------
 //   DP0 |   0 | a variable, bound to the 1st argument of a duplication
 //   DP1 |   1 | a variable, bound to the 2nd argument of a duplication
@@ -33,7 +33,7 @@
 //   U60 |  11 | a 60-bit unsigned integer
 //   F60 |  12 | a 60-bit floating point
 //
-// The semantics of the 1st and 2nd values depend on the pointer tag. 
+// The semantics of the 1st and 2nd values depend on the pointer tag.
 //
 //   Tag | 1st ptr value                | 2nd ptr value
 //   --- | ---------------------------- | ---------------------------------
@@ -68,7 +68,7 @@
 //   Lambda Node:
 //   - [0] => either and ERA or an ERA pointing to the variable location
 //   - [1] => pointer to the lambda's body
-//   
+//
 //   Application Node:
 //   - [0] => pointer to the lambda
 //   - [1] => pointer to the argument
@@ -102,7 +102,7 @@
 //   5. Function and Constructor arities depends on the user-provided definition.
 //
 // Example 0:
-// 
+//
 //   Core:
 //
 //    {Tuple2 #7 #8}
@@ -114,7 +114,7 @@
 //     0x01 | Ptr(U60, 0x0000000, 0x00000008) // the tuple's 2nd field
 //
 //   Notes:
-//     
+//
 //     1. This is just a pair with two numbers.
 //     2. The root pointer is not stored on memory.
 //     3. The 'Tuple2' name was encoded as the ID 1.
@@ -140,11 +140,11 @@
 //     2. The 1st lambda's argument not used, thus, an ERA pointer.
 //     3. The 2nd lambda's argument points to its variable, and vice-versa.
 //     4. Each lambda uses 2 memory slots. This term uses 64 bytes in total.
-//     
+//
 // Example 2:
 //
 //   Core:
-//     
+//
 //     λx dup x0 x1 = x; (* x0 x1)
 //
 //   Memory:
@@ -159,7 +159,7 @@
 //     0x06 | Ptr(DP1, 0xa31fb21, 0x00000002) // the operator's 2st operand
 //
 //   Notes:
-//     
+//
 //     1. This is a lambda function that squares a number.
 //     2. Notice how every ARGs point to a VAR/DP0/DP1, that points back its source node.
 //     3. DP1 does not point to its ARG. It points to the duplication node, which is at 0x02.
@@ -169,10 +169,10 @@
 //     7. A lambda uses 2 memory slots, a duplication uses 3, an operator uses 2. Total: 112 bytes.
 //     8. In-memory size is different to, and larger than, serialization size.
 
-pub use crate::runtime::{*};
+pub use crate::runtime::*;
 
-use std::sync::atomic::{AtomicU8, AtomicU64, AtomicI64, Ordering};
-use crossbeam::utils::{CachePadded, Backoff};
+use crossbeam::utils::{Backoff, CachePadded};
+use std::sync::atomic::{AtomicI64, AtomicU64, AtomicU8, Ordering};
 
 // Types
 // -----
@@ -233,7 +233,7 @@ pub const MUL: u64 = 0x2;
 pub const DIV: u64 = 0x3;
 pub const MOD: u64 = 0x4;
 pub const AND: u64 = 0x5;
-pub const OR : u64 = 0x6;
+pub const OR: u64 = 0x6;
 pub const XOR: u64 = 0x7;
 pub const SHL: u64 = 0x8;
 pub const SHR: u64 = 0x9;
@@ -386,20 +386,24 @@ pub fn link(heap: &Heap, loc: u64, ptr: Ptr) -> Ptr {
 // -----------------
 
 pub fn new_atomic_u8_array(size: usize) -> Box<[AtomicU8]> {
-  return unsafe { Box::from_raw(AtomicU8::from_mut_slice(Box::leak(vec![0xFFu8; size].into_boxed_slice()))) }
+  return unsafe {
+    Box::from_raw(AtomicU8::from_mut_slice(Box::leak(vec![0xFFu8; size].into_boxed_slice())))
+  };
 }
 
 pub fn new_atomic_u64_array(size: usize) -> Box<[AtomicU64]> {
-  return unsafe { Box::from_raw(AtomicU64::from_mut_slice(Box::leak(vec![0u64; size].into_boxed_slice()))) }
+  return unsafe {
+    Box::from_raw(AtomicU64::from_mut_slice(Box::leak(vec![0u64; size].into_boxed_slice())))
+  };
 }
 
 pub fn new_tids(tids: usize) -> Box<[usize]> {
-  return (0 .. tids).collect::<Vec<usize>>().into_boxed_slice();
+  return (0..tids).collect::<Vec<usize>>().into_boxed_slice();
 }
 
 pub fn new_heap(size: usize, tids: usize) -> Heap {
   let mut lvar = vec![];
-  for tid in 0 .. tids {
+  for tid in 0..tids {
     lvar.push(CachePadded::new(LocalVars {
       tid: tid,
       used: AtomicI64::new(0),
@@ -414,9 +418,15 @@ pub fn new_heap(size: usize, tids: usize) -> Heap {
   let lock = new_atomic_u8_array(size);
   let lvar = lvar.into_boxed_slice();
   let rbag = RedexBag::new(tids);
-  let aloc = (0 .. tids).map(|x| new_atomic_u64_array(1 << 20)).collect::<Vec<Box<[AtomicU64]>>>().into_boxed_slice();
-  let vbuf = (0 .. tids).map(|x| new_atomic_u64_array(1 << 16)).collect::<Vec<Box<[AtomicU64]>>>().into_boxed_slice();
-  let vstk = (0 .. tids).map(|x| VisitQueue::new()).collect::<Vec<VisitQueue>>().into_boxed_slice();
+  let aloc = (0..tids)
+    .map(|x| new_atomic_u64_array(1 << 20))
+    .collect::<Vec<Box<[AtomicU64]>>>()
+    .into_boxed_slice();
+  let vbuf = (0..tids)
+    .map(|x| new_atomic_u64_array(1 << 16))
+    .collect::<Vec<Box<[AtomicU64]>>>()
+    .into_boxed_slice();
+  let vstk = (0..tids).map(|x| VisitQueue::new()).collect::<Vec<VisitQueue>>().into_boxed_slice();
   return Heap { tids, node, lock, lvar, rbag, aloc, vbuf, vstk };
 }
 
@@ -434,7 +444,7 @@ pub fn alloc(heap: &Heap, tid: usize, arity: u64) -> u64 {
       loop {
         //count += 1;
         //if tid == 9 && count > 5000000 {
-          //println!("[9] slow-alloc {} | {}", count, *lvar.next.as_mut_ptr());
+        //println!("[9] slow-alloc {} | {}", count, *lvar.next.as_mut_ptr());
         //}
         // Loads value on cursor
         let val = heap.node.get_unchecked(*lvar.next.as_mut_ptr() as usize).load(Ordering::Relaxed);
@@ -458,7 +468,7 @@ pub fn alloc(heap: &Heap, tid: usize, arity: u64) -> u64 {
           //println!("[{}] alloc {} at {}", lvar.tid, arity, lvar.next - length);
           //lvar.used.fetch_add(arity as i64, Ordering::Relaxed);
           //if tid == 9 && count > 50000 {
-            //println!("[{}] allocated {}! {}", 9, length, *lvar.next.as_mut_ptr() - length);
+          //println!("[{}] allocated {}! {}", 9, length, *lvar.next.as_mut_ptr() - length);
           //}
           return *lvar.next.as_mut_ptr() - length;
         }
@@ -468,7 +478,7 @@ pub fn alloc(heap: &Heap, tid: usize, arity: u64) -> u64 {
 }
 
 pub fn free(heap: &Heap, tid: usize, loc: u64, arity: u64) {
-  for i in 0 .. arity {
+  for i in 0..arity {
     unsafe { heap.node.get_unchecked((loc + i) as usize) }.store(0, Ordering::Relaxed);
   }
 }
@@ -479,7 +489,12 @@ pub fn free(heap: &Heap, tid: usize, loc: u64, arity: u64) {
 // Atomically replaces a ptr by another. Updates binders.
 pub fn atomic_relink(heap: &Heap, loc: u64, old: Ptr, neo: Ptr) -> Result<Ptr, Ptr> {
   unsafe {
-    let got = heap.node.get_unchecked(loc as usize).compare_exchange_weak(old, neo, Ordering::Relaxed, Ordering::Relaxed)?;
+    let got = heap.node.get_unchecked(loc as usize).compare_exchange_weak(
+      old,
+      neo,
+      Ordering::Relaxed,
+      Ordering::Relaxed,
+    )?;
     if get_tag(neo) <= VAR {
       let arg_loc = get_loc(neo, get_tag(neo) & 0x01);
       heap.node.get_unchecked(arg_loc as usize).store(Arg(loc), Ordering::Relaxed);
@@ -514,7 +529,7 @@ pub fn atomic_subst(heap: &Heap, arit: &ArityMap, tid: usize, var: Ptr, val: Ptr
 // Locks
 // -----
 
-pub const LOCK_OPEN : u8 = 0xFF;
+pub const LOCK_OPEN: u8 = 0xFF;
 
 pub fn acquire_lock(heap: &Heap, tid: usize, term: Ptr) -> Result<u8, u8> {
   let locker = unsafe { heap.lock.get_unchecked(get_loc(term, 0) as usize) };
@@ -576,7 +591,7 @@ pub fn release_lock(heap: &Heap, tid: usize, term: Ptr) {
 // λf λx b0
 // dup f0 f1 = f
 // dup b0 b1 = (f0 (f1 {b1 x}))
-// 
+//
 // If we attempt to collect it with the algorithm above, we'll have:
 //
 // dup f0 f1 = ~
@@ -623,7 +638,7 @@ pub fn collect(heap: &Heap, arit: &ArityMap, tid: usize, term: Ptr) {
         link(heap, get_loc(term, 0), Era());
       }
       LAM => {
-        atomic_subst(heap, arit, tid, Var(get_loc(term,0)), Era());
+        atomic_subst(heap, arit, tid, Var(get_loc(term, 0)), Era());
         next = take_arg(heap, term, 1);
         free(heap, tid, get_loc(term, 0), 2);
         continue;
@@ -650,7 +665,7 @@ pub fn collect(heap: &Heap, arit: &ArityMap, tid: usize, term: Ptr) {
       F60 => {}
       CTR | FUN => {
         let arity = arity_of(arit, term);
-        for i in 0 .. arity {
+        for i in 0..arity {
           if i < arity - 1 {
             coll.push(take_arg(heap, term, i));
           } else {

--- a/src/runtime/base/mod.rs
+++ b/src/runtime/base/mod.rs
@@ -4,9 +4,8 @@ pub mod precomp;
 pub mod program;
 pub mod reducer;
 
-pub use debug::{*};
-pub use memory::{*};
-pub use precomp::{*};
-pub use program::{*};
-pub use reducer::{*};
-
+pub use debug::*;
+pub use memory::*;
+pub use precomp::*;
+pub use program::*;
+pub use reducer::*;

--- a/src/runtime/base/precomp.rs
+++ b/src/runtime/base/precomp.rs
@@ -1,4 +1,4 @@
-use crate::runtime::{*};
+use crate::runtime::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 // Precomps
@@ -16,247 +16,113 @@ pub struct Precomp {
   pub funs: Option<PrecompFuns>,
 }
 
-pub const STRING_NIL : u64 = 0;
-pub const STRING_CONS : u64 = 1;
-pub const BOTH : u64 = 2;
-pub const KIND_TERM_CT0 : u64 = 3;
-pub const KIND_TERM_CT1 : u64 = 4;
-pub const KIND_TERM_CT2 : u64 = 5;
-pub const KIND_TERM_CT3 : u64 = 6;
-pub const KIND_TERM_CT4 : u64 = 7;
-pub const KIND_TERM_CT5 : u64 = 8;
-pub const KIND_TERM_CT6 : u64 = 9;
-pub const KIND_TERM_CT7 : u64 = 10;
-pub const KIND_TERM_CT8 : u64 = 11;
-pub const KIND_TERM_CT9 : u64 = 12;
-pub const KIND_TERM_CTA : u64 = 13;
-pub const KIND_TERM_CTB : u64 = 14;
-pub const KIND_TERM_CTC : u64 = 15;
-pub const KIND_TERM_CTD : u64 = 16;
-pub const KIND_TERM_CTE : u64 = 17;
-pub const KIND_TERM_CTF : u64 = 18;
-pub const KIND_TERM_CTG : u64 = 19;
-pub const KIND_TERM_U60 : u64 = 20;
-pub const KIND_TERM_F60 : u64 = 21;
-pub const U60_IF : u64 = 22;
-pub const U60_SWAP : u64 = 23;
-pub const HVM_LOG : u64 = 24;
-pub const HVM_QUERY : u64 = 25;
-pub const HVM_PRINT : u64 = 26;
-pub const HVM_SLEEP : u64 = 27;
-pub const HVM_STORE : u64 = 28;
-pub const HVM_LOAD : u64 = 29;
+pub const STRING_NIL: u64 = 0;
+pub const STRING_CONS: u64 = 1;
+pub const BOTH: u64 = 2;
+pub const KIND_TERM_CT0: u64 = 3;
+pub const KIND_TERM_CT1: u64 = 4;
+pub const KIND_TERM_CT2: u64 = 5;
+pub const KIND_TERM_CT3: u64 = 6;
+pub const KIND_TERM_CT4: u64 = 7;
+pub const KIND_TERM_CT5: u64 = 8;
+pub const KIND_TERM_CT6: u64 = 9;
+pub const KIND_TERM_CT7: u64 = 10;
+pub const KIND_TERM_CT8: u64 = 11;
+pub const KIND_TERM_CT9: u64 = 12;
+pub const KIND_TERM_CTA: u64 = 13;
+pub const KIND_TERM_CTB: u64 = 14;
+pub const KIND_TERM_CTC: u64 = 15;
+pub const KIND_TERM_CTD: u64 = 16;
+pub const KIND_TERM_CTE: u64 = 17;
+pub const KIND_TERM_CTF: u64 = 18;
+pub const KIND_TERM_CTG: u64 = 19;
+pub const KIND_TERM_U60: u64 = 20;
+pub const KIND_TERM_F60: u64 = 21;
+pub const U60_IF: u64 = 22;
+pub const U60_SWAP: u64 = 23;
+pub const HVM_LOG: u64 = 24;
+pub const HVM_QUERY: u64 = 25;
+pub const HVM_PRINT: u64 = 26;
+pub const HVM_SLEEP: u64 = 27;
+pub const HVM_STORE: u64 = 28;
+pub const HVM_LOAD: u64 = 29;
 //[[CODEGEN:PRECOMP-IDS]]//
 
-pub const PRECOMP : &[Precomp] = &[
-  Precomp {
-    id: STRING_NIL,
-    name: "String.nil",
-    smap: &[false; 0],
-    funs: None,
-  },
-  Precomp {
-    id: STRING_CONS,
-    name: "String.cons",
-    smap: &[false; 2],
-    funs: None,
-  },
-  Precomp {
-    id: BOTH,
-    name: "Both",
-    smap: &[false; 2],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CT0,
-    name: "Kind.Term.ct0",
-    smap: &[false; 2],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CT1,
-    name: "Kind.Term.ct1",
-    smap: &[false; 3],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CT2,
-    name: "Kind.Term.ct2",
-    smap: &[false; 4],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CT3,
-    name: "Kind.Term.ct3",
-    smap: &[false; 5],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CT4,
-    name: "Kind.Term.ct4",
-    smap: &[false; 6],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CT5,
-    name: "Kind.Term.ct5",
-    smap: &[false; 7],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CT6,
-    name: "Kind.Term.ct6",
-    smap: &[false; 8],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CT7,
-    name: "Kind.Term.ct7",
-    smap: &[false; 9],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CT8,
-    name: "Kind.Term.ct8",
-    smap: &[false; 10],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CT9,
-    name: "Kind.Term.ct9",
-    smap: &[false; 11],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CTA,
-    name: "Kind.Term.ctA",
-    smap: &[false; 12],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CTB,
-    name: "Kind.Term.ctB",
-    smap: &[false; 13],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CTC,
-    name: "Kind.Term.ctC",
-    smap: &[false; 14],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CTD,
-    name: "Kind.Term.ctD",
-    smap: &[false; 15],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CTE,
-    name: "Kind.Term.ctE",
-    smap: &[false; 16],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CTF,
-    name: "Kind.Term.ctF",
-    smap: &[false; 17],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_CTG,
-    name: "Kind.Term.ctG",
-    smap: &[false; 18],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_U60,
-    name: "Kind.Term.u60",
-    smap: &[false; 2],
-    funs: None,
-  },
-  Precomp {
-    id: KIND_TERM_F60,
-    name: "Kind.Term.f60",
-    smap: &[false; 2],
-    funs: None,
-  },
+pub const PRECOMP: &[Precomp] = &[
+  Precomp { id: STRING_NIL, name: "String.nil", smap: &[false; 0], funs: None },
+  Precomp { id: STRING_CONS, name: "String.cons", smap: &[false; 2], funs: None },
+  Precomp { id: BOTH, name: "Both", smap: &[false; 2], funs: None },
+  Precomp { id: KIND_TERM_CT0, name: "Kind.Term.ct0", smap: &[false; 2], funs: None },
+  Precomp { id: KIND_TERM_CT1, name: "Kind.Term.ct1", smap: &[false; 3], funs: None },
+  Precomp { id: KIND_TERM_CT2, name: "Kind.Term.ct2", smap: &[false; 4], funs: None },
+  Precomp { id: KIND_TERM_CT3, name: "Kind.Term.ct3", smap: &[false; 5], funs: None },
+  Precomp { id: KIND_TERM_CT4, name: "Kind.Term.ct4", smap: &[false; 6], funs: None },
+  Precomp { id: KIND_TERM_CT5, name: "Kind.Term.ct5", smap: &[false; 7], funs: None },
+  Precomp { id: KIND_TERM_CT6, name: "Kind.Term.ct6", smap: &[false; 8], funs: None },
+  Precomp { id: KIND_TERM_CT7, name: "Kind.Term.ct7", smap: &[false; 9], funs: None },
+  Precomp { id: KIND_TERM_CT8, name: "Kind.Term.ct8", smap: &[false; 10], funs: None },
+  Precomp { id: KIND_TERM_CT9, name: "Kind.Term.ct9", smap: &[false; 11], funs: None },
+  Precomp { id: KIND_TERM_CTA, name: "Kind.Term.ctA", smap: &[false; 12], funs: None },
+  Precomp { id: KIND_TERM_CTB, name: "Kind.Term.ctB", smap: &[false; 13], funs: None },
+  Precomp { id: KIND_TERM_CTC, name: "Kind.Term.ctC", smap: &[false; 14], funs: None },
+  Precomp { id: KIND_TERM_CTD, name: "Kind.Term.ctD", smap: &[false; 15], funs: None },
+  Precomp { id: KIND_TERM_CTE, name: "Kind.Term.ctE", smap: &[false; 16], funs: None },
+  Precomp { id: KIND_TERM_CTF, name: "Kind.Term.ctF", smap: &[false; 17], funs: None },
+  Precomp { id: KIND_TERM_CTG, name: "Kind.Term.ctG", smap: &[false; 18], funs: None },
+  Precomp { id: KIND_TERM_U60, name: "Kind.Term.u60", smap: &[false; 2], funs: None },
+  Precomp { id: KIND_TERM_F60, name: "Kind.Term.f60", smap: &[false; 2], funs: None },
   Precomp {
     id: U60_IF,
     name: "U60.if",
     smap: &[true, false, false],
-    funs: Some(PrecompFuns {
-      visit: u60_if_visit,
-      apply: u60_if_apply,
-    }),
+    funs: Some(PrecompFuns { visit: u60_if_visit, apply: u60_if_apply }),
   },
   Precomp {
     id: U60_SWAP,
     name: "U60.swap",
     smap: &[true, false, false],
-    funs: Some(PrecompFuns {
-      visit: u60_swap_visit,
-      apply: u60_swap_apply,
-    }),
+    funs: Some(PrecompFuns { visit: u60_swap_visit, apply: u60_swap_apply }),
   },
   Precomp {
     id: HVM_LOG,
     name: "HVM.log",
     smap: &[false; 2],
-    funs: Some(PrecompFuns {
-      visit: hvm_log_visit,
-      apply: hvm_log_apply,
-    }),
+    funs: Some(PrecompFuns { visit: hvm_log_visit, apply: hvm_log_apply }),
   },
   Precomp {
     id: HVM_QUERY,
     name: "HVM.query",
     smap: &[false; 1],
-    funs: Some(PrecompFuns {
-      visit: hvm_query_visit,
-      apply: hvm_query_apply,
-    }),
+    funs: Some(PrecompFuns { visit: hvm_query_visit, apply: hvm_query_apply }),
   },
   Precomp {
     id: HVM_PRINT,
     name: "HVM.print",
     smap: &[false; 2],
-    funs: Some(PrecompFuns {
-      visit: hvm_print_visit,
-      apply: hvm_print_apply,
-    }),
+    funs: Some(PrecompFuns { visit: hvm_print_visit, apply: hvm_print_apply }),
   },
   Precomp {
     id: HVM_SLEEP,
     name: "HVM.sleep",
     smap: &[false; 2],
-    funs: Some(PrecompFuns {
-      visit: hvm_sleep_visit,
-      apply: hvm_sleep_apply,
-    }),
+    funs: Some(PrecompFuns { visit: hvm_sleep_visit, apply: hvm_sleep_apply }),
   },
   Precomp {
     id: HVM_STORE,
     name: "HVM.store",
     smap: &[false; 3],
-    funs: Some(PrecompFuns {
-      visit: hvm_store_visit,
-      apply: hvm_store_apply,
-    }),
+    funs: Some(PrecompFuns { visit: hvm_store_visit, apply: hvm_store_apply }),
   },
   Precomp {
     id: HVM_LOAD,
     name: "HVM.load",
     smap: &[false; 2],
-    funs: Some(PrecompFuns {
-      visit: hvm_load_visit,
-      apply: hvm_load_apply,
-    }),
+    funs: Some(PrecompFuns { visit: hvm_load_visit, apply: hvm_load_apply }),
   },
-//[[CODEGEN:PRECOMP-ELS]]//
+  //[[CODEGEN:PRECOMP-ELS]]//
 ];
 
-pub const PRECOMP_COUNT : u64 = PRECOMP.len() as u64;
+pub const PRECOMP_COUNT: u64 = PRECOMP.len() as u64;
 
 // Ul0.if (cond: Term) (if_t: Term) (if_f: Term)
 // ---------------------------------------------
@@ -374,11 +240,15 @@ fn hvm_query_visit(ctx: ReduceCtx) -> bool {
 
 fn hvm_query_apply(ctx: ReduceCtx) -> bool {
   fn read_input() -> String {
-    use std::io::{stdin,stdout,Write};
+    use std::io::{stdin, stdout, Write};
     let mut input = String::new();
     stdin().read_line(&mut input).expect("string");
-    if let Some('\n') = input.chars().next_back() { input.pop(); }
-    if let Some('\r') = input.chars().next_back() { input.pop(); }
+    if let Some('\n') = input.chars().next_back() {
+      input.pop();
+    }
+    if let Some('\r') = input.chars().next_back() {
+      input.pop();
+    }
     return input;
   }
   let cont = load_arg(ctx.heap, ctx.term, 0);
@@ -401,7 +271,9 @@ fn hvm_print_visit(ctx: ReduceCtx) -> bool {
 
 fn hvm_print_apply(ctx: ReduceCtx) -> bool {
   //normalize(ctx.heap, ctx.prog, &[ctx.tid], get_loc(ctx.term, 0), false);
-  if let Some(text) = crate::language::readback::as_string(ctx.heap, ctx.prog, &[ctx.tid], get_loc(ctx.term, 0)) {
+  if let Some(text) =
+    crate::language::readback::as_string(ctx.heap, ctx.prog, &[ctx.tid], get_loc(ctx.term, 0))
+  {
     println!("{}", text);
   }
   link(ctx.heap, *ctx.host, load_arg(ctx.heap, ctx.term, 1));
@@ -433,8 +305,12 @@ fn hvm_store_visit(ctx: ReduceCtx) -> bool {
 }
 
 fn hvm_store_apply(ctx: ReduceCtx) -> bool {
-  if let Some(key) = crate::language::readback::as_string(ctx.heap, ctx.prog, &[ctx.tid], get_loc(ctx.term, 0)) {
-    if let Some(val) = crate::language::readback::as_string(ctx.heap, ctx.prog, &[ctx.tid], get_loc(ctx.term, 1)) {
+  if let Some(key) =
+    crate::language::readback::as_string(ctx.heap, ctx.prog, &[ctx.tid], get_loc(ctx.term, 0))
+  {
+    if let Some(val) =
+      crate::language::readback::as_string(ctx.heap, ctx.prog, &[ctx.tid], get_loc(ctx.term, 1))
+    {
       if std::fs::write(key, val).is_ok() {
         //let app0 = alloc(ctx.heap, ctx.tid, 2);
         //link(ctx.heap, app0 + 0, cont);
@@ -461,10 +337,12 @@ fn hvm_load_visit(ctx: ReduceCtx) -> bool {
 }
 
 fn hvm_load_apply(ctx: ReduceCtx) -> bool {
-  if let Some(key) = crate::language::readback::as_string(ctx.heap, ctx.prog, &[ctx.tid], get_loc(ctx.term, 0)) {
+  if let Some(key) =
+    crate::language::readback::as_string(ctx.heap, ctx.prog, &[ctx.tid], get_loc(ctx.term, 0))
+  {
     if let Ok(file) = std::fs::read(key) {
       if let Ok(file) = std::str::from_utf8(&file) {
-        let cont = load_arg(ctx.heap, ctx.term, 1); 
+        let cont = load_arg(ctx.heap, ctx.term, 1);
         let text = make_string(ctx.heap, ctx.tid, file);
         let app0 = alloc(ctx.heap, ctx.tid, 2);
         link(ctx.heap, app0 + 0, cont);

--- a/src/runtime/base/precomp.rs
+++ b/src/runtime/base/precomp.rs
@@ -130,12 +130,12 @@ pub const PRECOMP_COUNT: u64 = PRECOMP.len() as u64;
 #[inline(always)]
 pub fn u60_if_visit(ctx: ReduceCtx) -> bool {
   if is_whnf(load_arg(ctx.heap, ctx.term, 0)) {
-    return false;
+    false
   } else {
     let goup = ctx.redex.insert(ctx.tid, new_redex(*ctx.host, *ctx.cont, 1));
     *ctx.cont = goup;
     *ctx.host = get_loc(ctx.term, 0);
-    return true;
+    true
   }
 }
 
@@ -164,7 +164,7 @@ pub fn u60_if_apply(ctx: ReduceCtx) -> bool {
       return true;
     }
   }
-  return false;
+  false
 }
 
 // U60.swap (cond: Term) (pair: Term)
@@ -173,12 +173,12 @@ pub fn u60_if_apply(ctx: ReduceCtx) -> bool {
 #[inline(always)]
 pub fn u60_swap_visit(ctx: ReduceCtx) -> bool {
   if is_whnf(load_arg(ctx.heap, ctx.term, 0)) {
-    return false;
+    false
   } else {
     let goup = ctx.redex.insert(ctx.tid, new_redex(*ctx.host, *ctx.cont, 1));
     *ctx.cont = goup;
     *ctx.host = get_loc(ctx.term, 0);
-    return true;
+    true
   }
 }
 
@@ -211,31 +211,31 @@ pub fn u60_swap_apply(ctx: ReduceCtx) -> bool {
       return true;
     }
   }
-  return false;
+  false
 }
 
 // HVM.log (term: Term)
 // --------------------
 
 fn hvm_log_visit(ctx: ReduceCtx) -> bool {
-  return false;
+  false
 }
 
 fn hvm_log_apply(ctx: ReduceCtx) -> bool {
   normalize(ctx.heap, ctx.prog, &[ctx.tid], get_loc(ctx.term, 0), false);
   let code = crate::language::readback::as_code(ctx.heap, ctx.prog, get_loc(ctx.term, 0));
-  println!("{}", code);
+  println!("{code}");
   link(ctx.heap, *ctx.host, load_arg(ctx.heap, ctx.term, 1));
   collect(ctx.heap, &ctx.prog.aris, ctx.tid, load_ptr(ctx.heap, get_loc(ctx.term, 0)));
   free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 2);
-  return true;
+  true
 }
 
 // HVM.query (cont: String -> Term)
 // --------------------------------
 
 fn hvm_query_visit(ctx: ReduceCtx) -> bool {
-  return false;
+  false
 }
 
 fn hvm_query_apply(ctx: ReduceCtx) -> bool {
@@ -249,7 +249,7 @@ fn hvm_query_apply(ctx: ReduceCtx) -> bool {
     if let Some('\r') = input.chars().next_back() {
       input.pop();
     }
-    return input;
+    input
   }
   let cont = load_arg(ctx.heap, ctx.term, 0);
   let text = make_string(ctx.heap, ctx.tid, &read_input());
@@ -259,14 +259,14 @@ fn hvm_query_apply(ctx: ReduceCtx) -> bool {
   free(ctx.heap, 0, get_loc(ctx.term, 0), 1);
   let done = App(app0);
   link(ctx.heap, *ctx.host, done);
-  return true;
+  true
 }
 
 // HVM.print (text: String) (cont: Term)
 // -----------------------------------------------
 
 fn hvm_print_visit(ctx: ReduceCtx) -> bool {
-  return false;
+  false
 }
 
 fn hvm_print_apply(ctx: ReduceCtx) -> bool {
@@ -274,19 +274,19 @@ fn hvm_print_apply(ctx: ReduceCtx) -> bool {
   if let Some(text) =
     crate::language::readback::as_string(ctx.heap, ctx.prog, &[ctx.tid], get_loc(ctx.term, 0))
   {
-    println!("{}", text);
+    println!("{text}");
   }
   link(ctx.heap, *ctx.host, load_arg(ctx.heap, ctx.term, 1));
   collect(ctx.heap, &ctx.prog.aris, ctx.tid, load_ptr(ctx.heap, get_loc(ctx.term, 0)));
   free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 2);
-  return true;
+  true
 }
 
 // HVM.sleep (time: U60) (cont: Term)
 // ----------------------------------
 
 fn hvm_sleep_visit(ctx: ReduceCtx) -> bool {
-  return false;
+  false
 }
 
 fn hvm_sleep_apply(ctx: ReduceCtx) -> bool {
@@ -294,14 +294,14 @@ fn hvm_sleep_apply(ctx: ReduceCtx) -> bool {
   std::thread::sleep(std::time::Duration::from_nanos(get_num(time)));
   link(ctx.heap, *ctx.host, load_ptr(ctx.heap, get_loc(ctx.term, 1)));
   free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 2);
-  return true;
+  true
 }
 
 // HVM.store (key: String) (val: String) (cont: Term)
 // --------------------------------------------------
 
 fn hvm_store_visit(ctx: ReduceCtx) -> bool {
-  return false;
+  false
 }
 
 fn hvm_store_apply(ctx: ReduceCtx) -> bool {
@@ -333,7 +333,7 @@ fn hvm_store_apply(ctx: ReduceCtx) -> bool {
 // ---------------------------------------------
 
 fn hvm_load_visit(ctx: ReduceCtx) -> bool {
-  return false;
+  false
 }
 
 fn hvm_load_apply(ctx: ReduceCtx) -> bool {

--- a/src/runtime/base/reducer.rs
+++ b/src/runtime/base/reducer.rs
@@ -1,18 +1,18 @@
-pub use crate::runtime::{*};
-use crossbeam::utils::{Backoff};
+pub use crate::runtime::*;
+use crossbeam::utils::Backoff;
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicBool, AtomicUsize, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 pub struct ReduceCtx<'a> {
-  pub heap  : &'a Heap,
-  pub prog  : &'a Program,
-  pub tid   : usize,
-  pub hold  : bool,
-  pub term  : Ptr,
-  pub visit : &'a VisitQueue,
-  pub redex : &'a RedexBag,
-  pub cont  : &'a mut u64,
-  pub host  : &'a mut u64,
+  pub heap: &'a Heap,
+  pub prog: &'a Program,
+  pub tid: usize,
+  pub hold: bool,
+  pub term: Ptr,
+  pub visit: &'a VisitQueue,
+  pub redex: &'a RedexBag,
+  pub cont: &'a mut u64,
+  pub host: &'a mut u64,
 }
 
 // HVM's reducer is a finite stack machine with 4 possible states:
@@ -40,11 +40,18 @@ pub fn is_whnf(term: Ptr) -> bool {
     CTR => true,
     U60 => true,
     F60 => true,
-    _   => false,
+    _ => false,
   }
 }
 
-pub fn reduce(heap: &Heap, prog: &Program, tids: &[usize], root: u64, full: bool, debug: bool) -> Ptr {
+pub fn reduce(
+  heap: &Heap,
+  prog: &Program,
+  tids: &[usize],
+  root: u64,
+  full: bool,
+  debug: bool,
+) -> Ptr {
   // Halting flag
   let stop = &AtomicUsize::new(1);
   let barr = &Barrier::new(tids.len());
@@ -76,20 +83,15 @@ pub fn reducer(
   full: bool,
   debug: bool,
 ) {
-
   // State Stacks
   let redex = &heap.rbag;
   let visit = &heap.vstk[tid];
   let bkoff = &Backoff::new();
-  let hold  = tids.len() <= 1;
-  let seen  = &mut HashSet::new();
+  let hold = tids.len() <= 1;
+  let seen = &mut HashSet::new();
 
   // State Vars
-  let (mut cont, mut host) = if tid == tids[0] {
-    (REDEX_CONT_RET, root)
-  } else {
-    (0, u64::MAX)
-  };
+  let (mut cont, mut host) = if tid == tids[0] { (REDEX_CONT_RET, root) } else { (0, u64::MAX) };
 
   // Debug Printer
   let print = |tid: usize, host: u64| {
@@ -116,7 +118,17 @@ pub fn reducer(
           }
           match get_tag(term) {
             APP => {
-              if app::visit(ReduceCtx { heap, prog, tid, hold, term, visit, redex, cont: &mut cont, host: &mut host }) {
+              if app::visit(ReduceCtx {
+                heap,
+                prog,
+                tid,
+                hold,
+                term,
+                visit,
+                redex,
+                cont: &mut cont,
+                host: &mut host,
+              }) {
                 continue 'visit;
               } else {
                 break 'work;
@@ -133,7 +145,17 @@ pub fn reducer(
                     release_lock(heap, tid, term);
                     continue 'visit;
                   } else {
-                    if dup::visit(ReduceCtx { heap, prog, tid, hold, term, visit, redex, cont: &mut cont, host: &mut host }) {
+                    if dup::visit(ReduceCtx {
+                      heap,
+                      prog,
+                      tid,
+                      hold,
+                      term,
+                      visit,
+                      redex,
+                      cont: &mut cont,
+                      host: &mut host,
+                    }) {
                       continue 'visit;
                     } else {
                       break 'work;
@@ -143,7 +165,17 @@ pub fn reducer(
               }
             }
             OP2 => {
-              if op2::visit(ReduceCtx { heap, prog, tid, hold, term, visit, redex, cont: &mut cont, host: &mut host }) {
+              if op2::visit(ReduceCtx {
+                heap,
+                prog,
+                tid,
+                hold,
+                term,
+                visit,
+                redex,
+                cont: &mut cont,
+                host: &mut host,
+              }) {
                 continue 'visit;
               } else {
                 break 'work;
@@ -151,17 +183,40 @@ pub fn reducer(
             }
             FUN | CTR => {
               let fid = get_ext(term);
-//[[CODEGEN:FAST-VISIT]]//
+              //[[CODEGEN:FAST-VISIT]]//
               match &prog.funs.get(&fid) {
                 Some(Function::Interpreted { smap: fn_smap, visit: fn_visit, apply: fn_apply }) => {
-                  if fun::visit(ReduceCtx { heap, prog, tid, hold, term, visit, redex, cont: &mut cont, host: &mut host }, &fn_visit.strict_idx) {
+                  if fun::visit(
+                    ReduceCtx {
+                      heap,
+                      prog,
+                      tid,
+                      hold,
+                      term,
+                      visit,
+                      redex,
+                      cont: &mut cont,
+                      host: &mut host,
+                    },
+                    &fn_visit.strict_idx,
+                  ) {
                     continue 'visit;
                   } else {
                     break 'visit;
                   }
                 }
                 Some(Function::Compiled { smap: fn_smap, visit: fn_visit, apply: fn_apply }) => {
-                  if fn_visit(ReduceCtx { heap, prog, tid, hold, term, visit, redex, cont: &mut cont, host: &mut host }) {
+                  if fn_visit(ReduceCtx {
+                    heap,
+                    prog,
+                    tid,
+                    hold,
+                    term,
+                    visit,
+                    redex,
+                    cont: &mut cont,
+                    host: &mut host,
+                  }) {
                     continue 'visit;
                   } else {
                     break 'visit;
@@ -186,14 +241,34 @@ pub fn reducer(
             // Apply rewrite rules
             match get_tag(term) {
               APP => {
-                if app::apply(ReduceCtx { heap, prog, tid, hold, term, visit, redex, cont: &mut cont, host: &mut host }) {
+                if app::apply(ReduceCtx {
+                  heap,
+                  prog,
+                  tid,
+                  hold,
+                  term,
+                  visit,
+                  redex,
+                  cont: &mut cont,
+                  host: &mut host,
+                }) {
                   continue 'work;
                 } else {
                   break 'apply;
                 }
               }
               DP0 | DP1 => {
-                if dup::apply(ReduceCtx { heap, prog, tid, hold, term, visit, redex, cont: &mut cont, host: &mut host }) {
+                if dup::apply(ReduceCtx {
+                  heap,
+                  prog,
+                  tid,
+                  hold,
+                  term,
+                  visit,
+                  redex,
+                  cont: &mut cont,
+                  host: &mut host,
+                }) {
                   release_lock(heap, tid, term);
                   continue 'work;
                 } else {
@@ -202,7 +277,17 @@ pub fn reducer(
                 }
               }
               OP2 => {
-                if op2::apply(ReduceCtx { heap, prog, tid, hold, term, visit, redex, cont: &mut cont, host: &mut host }) {
+                if op2::apply(ReduceCtx {
+                  heap,
+                  prog,
+                  tid,
+                  hold,
+                  term,
+                  visit,
+                  redex,
+                  cont: &mut cont,
+                  host: &mut host,
+                }) {
                   continue 'work;
                 } else {
                   break 'apply;
@@ -210,17 +295,46 @@ pub fn reducer(
               }
               FUN | CTR => {
                 let fid = get_ext(term);
-//[[CODEGEN:FAST-APPLY]]//
+                //[[CODEGEN:FAST-APPLY]]//
                 match &prog.funs.get(&fid) {
-                  Some(Function::Interpreted { smap: fn_smap, visit: fn_visit, apply: fn_apply }) => {
-                    if fun::apply(ReduceCtx { heap, prog, tid, hold, term, visit, redex, cont: &mut cont, host: &mut host }, fid, fn_visit, fn_apply) {
+                  Some(Function::Interpreted {
+                    smap: fn_smap,
+                    visit: fn_visit,
+                    apply: fn_apply,
+                  }) => {
+                    if fun::apply(
+                      ReduceCtx {
+                        heap,
+                        prog,
+                        tid,
+                        hold,
+                        term,
+                        visit,
+                        redex,
+                        cont: &mut cont,
+                        host: &mut host,
+                      },
+                      fid,
+                      fn_visit,
+                      fn_apply,
+                    ) {
                       continue 'work;
                     } else {
                       break 'apply;
                     }
                   }
                   Some(Function::Compiled { smap: fn_smap, visit: fn_visit, apply: fn_apply }) => {
-                    if fn_apply(ReduceCtx { heap, prog, tid, hold, term, visit, redex, cont: &mut cont, host: &mut host }) {
+                    if fn_apply(ReduceCtx {
+                      heap,
+                      prog,
+                      tid,
+                      hold,
+                      term,
+                      visit,
+                      redex,
+                      cont: &mut cont,
+                      host: &mut host,
+                    }) {
                       continue 'work;
                     } else {
                       break 'apply;
@@ -270,7 +384,7 @@ pub fn reducer(
                   let arit = arity_of(&prog.aris, term);
                   if arit > 0 {
                     stop.fetch_add(arit as usize, Ordering::Relaxed);
-                    for i in 0 .. arit {
+                    for i in 0..arit {
                       visit.push(new_visit(get_loc(term, i), hold, cont));
                     }
                   }
@@ -345,105 +459,105 @@ pub fn normalize(heap: &Heap, prog: &Program, tids: &[usize], host: u64, debug: 
 }
 
 //pub fn normal(heap: &Heap, prog: &Program, tids: &[usize], host: u64, seen: &mut im::HashSet<u64>, debug: bool) -> Ptr {
-  //let term = load_ptr(heap, host);
-  //if seen.contains(&host) {
-    //term
-  //} else {
-    ////let term = reduce2(heap, lvars, prog, host);
-    //let term = reduce(heap, prog, tids, host, debug);
-    //seen.insert(host);
-    //let mut rec_locs = vec![];
-    //match get_tag(term) {
-      //LAM => {
-        //rec_locs.push(get_loc(term, 1));
-      //}
-      //APP => {
-        //rec_locs.push(get_loc(term, 0));
-        //rec_locs.push(get_loc(term, 1));
-      //}
-      //SUP => {
-        //rec_locs.push(get_loc(term, 0));
-        //rec_locs.push(get_loc(term, 1));
-      //}
-      //DP0 => {
-        //rec_locs.push(get_loc(term, 2));
-      //}
-      //DP1 => {
-        //rec_locs.push(get_loc(term, 2));
-      //}
-      //CTR | FUN => {
-        //let arity = arity_of(&prog.aris, term);
-        //for i in 0 .. arity {
-          //rec_locs.push(get_loc(term, i));
-        //}
-      //}
-      //_ => {}
-    //}
-    //let rec_len = rec_locs.len(); // locations where we must recurse
-    //let thd_len = tids.len(); // number of available threads
-    //let rec_loc = &rec_locs;
-    ////println!("~ rec_len={} thd_len={} {}", rec_len, thd_len, show_term(heap, prog, ask_lnk(heap,host), host));
-    //if rec_len > 0 {
-      //std::thread::scope(|s| {
-        //// If there are more threads than rec_locs, splits threads for each rec_loc
-        //if thd_len >= rec_len {
-          ////panic!("b");
-          //let spt_len = thd_len / rec_len;
-          //let mut tids = tids;
-          //for (rec_num, rec_loc) in rec_loc.iter().enumerate() {
-            //let (rec_tids, new_tids) = tids.split_at(if rec_num == rec_len - 1 { tids.len() } else { spt_len });
-            ////println!("~ rec_loc {} gets {} threads", rec_loc, rec_lvars.len());
-            ////let new_loc;
-            ////if thd_len == rec_len {
-              ////new_loc = alloc(heap, rec_tids[0], 1);
-              ////move_ptr(heap, *rec_loc, new_loc);
-            ////} else {
-              ////new_loc = *rec_loc;
-            ////}
-            ////let new_loc = *rec_loc;
-            //let mut seen = seen.clone();
-            //s.spawn(move || {
-              //let ptr = normal(heap, prog, rec_tids, *rec_loc, &mut seen, debug);
-              ////if thd_len == rec_len {
-                ////move_ptr(heap, new_loc, *rec_loc);
-              ////}
-              //link(heap, *rec_loc, ptr);
-            //});
-            //tids = new_tids;
-          //}
-        //// Otherwise, splits rec_locs for each thread
-        //} else {
-          ////panic!("c");
-          //for (thd_num, tid) in tids.iter().enumerate() {
-            //let min_idx = thd_num * rec_len / thd_len;
-            //let max_idx = if thd_num < thd_len - 1 { (thd_num + 1) * rec_len / thd_len } else { rec_len };
-            ////println!("~ thread {} gets rec_locs {} to {}", thd_num, min_idx, max_idx);
-            //let mut seen = seen.clone();
-            //s.spawn(move || {
-              //for idx in min_idx .. max_idx {
-                //let loc = rec_loc[idx];
-                //let lnk = normal(heap, prog, std::slice::from_ref(tid), loc, &mut seen, debug);
-                //link(heap, loc, lnk);
-              //}
-            //});
-          //}
-        //}
-      //});
-    //}
-    //term
-  //}
+//let term = load_ptr(heap, host);
+//if seen.contains(&host) {
+//term
+//} else {
+////let term = reduce2(heap, lvars, prog, host);
+//let term = reduce(heap, prog, tids, host, debug);
+//seen.insert(host);
+//let mut rec_locs = vec![];
+//match get_tag(term) {
+//LAM => {
+//rec_locs.push(get_loc(term, 1));
+//}
+//APP => {
+//rec_locs.push(get_loc(term, 0));
+//rec_locs.push(get_loc(term, 1));
+//}
+//SUP => {
+//rec_locs.push(get_loc(term, 0));
+//rec_locs.push(get_loc(term, 1));
+//}
+//DP0 => {
+//rec_locs.push(get_loc(term, 2));
+//}
+//DP1 => {
+//rec_locs.push(get_loc(term, 2));
+//}
+//CTR | FUN => {
+//let arity = arity_of(&prog.aris, term);
+//for i in 0 .. arity {
+//rec_locs.push(get_loc(term, i));
+//}
+//}
+//_ => {}
+//}
+//let rec_len = rec_locs.len(); // locations where we must recurse
+//let thd_len = tids.len(); // number of available threads
+//let rec_loc = &rec_locs;
+////println!("~ rec_len={} thd_len={} {}", rec_len, thd_len, show_term(heap, prog, ask_lnk(heap,host), host));
+//if rec_len > 0 {
+//std::thread::scope(|s| {
+//// If there are more threads than rec_locs, splits threads for each rec_loc
+//if thd_len >= rec_len {
+////panic!("b");
+//let spt_len = thd_len / rec_len;
+//let mut tids = tids;
+//for (rec_num, rec_loc) in rec_loc.iter().enumerate() {
+//let (rec_tids, new_tids) = tids.split_at(if rec_num == rec_len - 1 { tids.len() } else { spt_len });
+////println!("~ rec_loc {} gets {} threads", rec_loc, rec_lvars.len());
+////let new_loc;
+////if thd_len == rec_len {
+////new_loc = alloc(heap, rec_tids[0], 1);
+////move_ptr(heap, *rec_loc, new_loc);
+////} else {
+////new_loc = *rec_loc;
+////}
+////let new_loc = *rec_loc;
+//let mut seen = seen.clone();
+//s.spawn(move || {
+//let ptr = normal(heap, prog, rec_tids, *rec_loc, &mut seen, debug);
+////if thd_len == rec_len {
+////move_ptr(heap, new_loc, *rec_loc);
+////}
+//link(heap, *rec_loc, ptr);
+//});
+//tids = new_tids;
+//}
+//// Otherwise, splits rec_locs for each thread
+//} else {
+////panic!("c");
+//for (thd_num, tid) in tids.iter().enumerate() {
+//let min_idx = thd_num * rec_len / thd_len;
+//let max_idx = if thd_num < thd_len - 1 { (thd_num + 1) * rec_len / thd_len } else { rec_len };
+////println!("~ thread {} gets rec_locs {} to {}", thd_num, min_idx, max_idx);
+//let mut seen = seen.clone();
+//s.spawn(move || {
+//for idx in min_idx .. max_idx {
+//let loc = rec_loc[idx];
+//let lnk = normal(heap, prog, std::slice::from_ref(tid), loc, &mut seen, debug);
+//link(heap, loc, lnk);
+//}
+//});
+//}
+//}
+//});
+//}
+//term
+//}
 //}
 
 //pub fn normalize(heap: &Heap, prog: &Program, tids: &[usize], host: u64, debug: bool) -> Ptr {
-  //let mut cost = get_cost(heap);
-  //loop {
-    //normal(heap, prog, tids, host, &mut im::HashSet::new(), debug);
-    //let new_cost = get_cost(heap);
-    //if new_cost != cost {
-      //cost = new_cost;
-    //} else {
-      //break;
-    //}
-  //}
-  //load_ptr(heap, host)
+//let mut cost = get_cost(heap);
+//loop {
+//normal(heap, prog, tids, host, &mut im::HashSet::new(), debug);
+//let new_cost = get_cost(heap);
+//if new_cost != cost {
+//cost = new_cost;
+//} else {
+//break;
+//}
+//}
+//load_ptr(heap, host)
 //}

--- a/src/runtime/base/reducer.rs
+++ b/src/runtime/base/reducer.rs
@@ -68,7 +68,7 @@ pub fn reduce(
   });
 
   // Return whnf term ptr
-  return load_ptr(heap, root);
+  load_ptr(heap, root)
 }
 
 pub fn reducer(
@@ -144,22 +144,20 @@ pub fn reducer(
                   if term != load_ptr(heap, host) {
                     release_lock(heap, tid, term);
                     continue 'visit;
+                  } else if dup::visit(ReduceCtx {
+                    heap,
+                    prog,
+                    tid,
+                    hold,
+                    term,
+                    visit,
+                    redex,
+                    cont: &mut cont,
+                    host: &mut host,
+                  }) {
+                    continue 'visit;
                   } else {
-                    if dup::visit(ReduceCtx {
-                      heap,
-                      prog,
-                      tid,
-                      hold,
-                      term,
-                      visit,
-                      redex,
-                      cont: &mut cont,
-                      host: &mut host,
-                    }) {
-                      continue 'visit;
-                    } else {
-                      break 'work;
-                    }
+                    break 'work;
                   }
                 }
               }

--- a/src/runtime/data/barrier.rs
+++ b/src/runtime/data/barrier.rs
@@ -8,7 +8,7 @@ pub struct Barrier {
 
 impl Barrier {
   pub fn new(tids: usize) -> Barrier {
-    Barrier { done: AtomicUsize::new(0), pass: AtomicUsize::new(0), tids: tids }
+    Barrier { done: AtomicUsize::new(0), pass: AtomicUsize::new(0), tids }
   }
 
   pub fn wait(&self, stop: &AtomicUsize) {

--- a/src/runtime/data/barrier.rs
+++ b/src/runtime/data/barrier.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicUsize, AtomicBool, Ordering, fence};
+use std::sync::atomic::{fence, AtomicBool, AtomicUsize, Ordering};
 
 pub struct Barrier {
   pub done: AtomicUsize,
@@ -8,11 +8,7 @@ pub struct Barrier {
 
 impl Barrier {
   pub fn new(tids: usize) -> Barrier {
-    Barrier {
-      done: AtomicUsize::new(0),
-      pass: AtomicUsize::new(0),
-      tids: tids,
-    }
+    Barrier { done: AtomicUsize::new(0), pass: AtomicUsize::new(0), tids: tids }
   }
 
   pub fn wait(&self, stop: &AtomicUsize) {

--- a/src/runtime/data/f60.rs
+++ b/src/runtime/data/f60.rs
@@ -4,9 +4,9 @@ type F60 = u64;
 pub fn new(a: f64) -> F60 {
   let b = a.to_bits();
   if b & 0b1111 > 8 {
-    return (b >> 4) + 1;
+    (b >> 4) + 1
   } else {
-    return b >> 4;
+    b >> 4
   }
 }
 
@@ -17,90 +17,90 @@ pub fn val(a: F60) -> f64 {
 
 #[inline(always)]
 pub fn add(a: F60, b: F60) -> F60 {
-  return new(val(a) + val(b));
+  new(val(a) + val(b))
 }
 
 #[inline(always)]
 pub fn sub(a: F60, b: F60) -> F60 {
-  return new(val(a) - val(b));
+  new(val(a) - val(b))
 }
 
 #[inline(always)]
 pub fn mul(a: F60, b: F60) -> F60 {
-  return new(val(a) * val(b));
+  new(val(a) * val(b))
 }
 
 #[inline(always)]
 pub fn div(a: F60, b: F60) -> F60 {
-  return new(val(a) / val(b));
+  new(val(a) / val(b))
 }
 
 #[inline(always)]
 pub fn mdl(a: F60, b: F60) -> F60 {
-  return new(val(a) % val(b));
+  new(val(a) % val(b))
 }
 
 #[inline(always)]
 pub fn and(a: F60, b: F60) -> F60 {
-  return new(f64::cos(val(a)) + f64::sin(val(b)));
+  new(f64::cos(val(a)) + f64::sin(val(b)))
 }
 
 #[inline(always)]
 pub fn or(a: F60, b: F60) -> F60 {
-  return new(f64::atan2(val(a), val(b)));
+  new(f64::atan2(val(a), val(b)))
 }
 
 #[inline(always)]
 pub fn shl(a: F60, b: F60) -> F60 {
-  return new(val(b).powf(val(a)));
+  new(val(b).powf(val(a)))
 }
 
 #[inline(always)]
 pub fn shr(a: F60, b: F60) -> F60 {
-  return new(val(a).log(val(b)));
+  new(val(a).log(val(b)))
 }
 
 #[inline(always)]
 pub fn xor(a: F60, b: F60) -> F60 {
-  return new(val(a).ceil() + val(a).floor());
+  new(val(a).ceil() + val(a).floor())
 }
 
 #[inline(always)]
 pub fn ltn(a: F60, b: F60) -> F60 {
-  return new(if val(a) < val(b) { 1.0 } else { 0.0 });
+  new(if val(a) < val(b) { 1.0 } else { 0.0 })
 }
 
 #[inline(always)]
 pub fn lte(a: F60, b: F60) -> F60 {
-  return new(if val(a) <= val(b) { 1.0 } else { 0.0 });
+  new(if val(a) <= val(b) { 1.0 } else { 0.0 })
 }
 
 #[inline(always)]
 pub fn eql(a: F60, b: F60) -> F60 {
-  return new(if val(a) == val(b) { 1.0 } else { 0.0 });
+  new(if val(a) == val(b) { 1.0 } else { 0.0 })
 }
 
 #[inline(always)]
 pub fn gte(a: F60, b: F60) -> F60 {
-  return new(if val(a) >= val(b) { 1.0 } else { 0.0 });
+  new(if val(a) >= val(b) { 1.0 } else { 0.0 })
 }
 
 #[inline(always)]
 pub fn gtn(a: F60, b: F60) -> F60 {
-  return new(if val(a) > val(b) { 1.0 } else { 0.0 });
+  new(if val(a) > val(b) { 1.0 } else { 0.0 })
 }
 
 #[inline(always)]
 pub fn neq(a: F60, b: F60) -> F60 {
-  return new(if val(a) != val(b) { 1.0 } else { 0.0 });
+  new(if val(a) != val(b) { 1.0 } else { 0.0 })
 }
 
 #[inline(always)]
 pub fn show(a: F60) -> String {
   let txt = format!("{}", val(a));
-  if txt.find(".").is_none() {
-    return format!("{}.0", txt);
+  if txt.find('.').is_none() {
+    format!("{txt}.0")
   } else {
-    return txt;
+    txt
   }
 }

--- a/src/runtime/data/mod.rs
+++ b/src/runtime/data/mod.rs
@@ -8,7 +8,7 @@ pub mod redex_bag;
 pub mod u64_map;
 pub mod visit_queue;
 
-pub use barrier::{*};
-pub use redex_bag::{*};
-pub use u64_map::{*};
-pub use visit_queue::{*};
+pub use barrier::*;
+pub use redex_bag::*;
+pub use u64_map::*;
+pub use visit_queue::*;

--- a/src/runtime/data/redex_bag.rs
+++ b/src/runtime/data/redex_bag.rs
@@ -20,19 +20,19 @@ pub struct RedexBag {
 }
 
 pub fn new_redex(host: u64, cont: u64, left: u64) -> Redex {
-  return (host << 32) | (cont << 6) | left;
+  (host << 32) | (cont << 6) | left
 }
 
 pub fn get_redex_host(redex: Redex) -> u64 {
-  return redex >> 32;
+  redex >> 32
 }
 
 pub fn get_redex_cont(redex: Redex) -> u64 {
-  return (redex >> 6) & 0x3FFFFFF;
+  (redex >> 6) & 0x3FFFFFF
 }
 
 pub fn get_redex_left(redex: Redex) -> u64 {
-  return redex & 0x3F;
+  redex & 0x3F
 }
 
 impl RedexBag {
@@ -43,7 +43,7 @@ impl RedexBag {
     }
     let next = next.into_boxed_slice();
     let data = crate::runtime::new_atomic_u64_array(REDEX_BAG_SIZE);
-    return RedexBag { tids, next, data };
+    RedexBag { tids, next, data }
   }
 
   //pub fn min_index(&self, tid: usize) -> usize {
@@ -75,9 +75,9 @@ impl RedexBag {
     let redex = unsafe { self.data.get_unchecked(index as usize) }.fetch_sub(1, Ordering::Relaxed);
     if get_redex_left(redex) == 1 {
       unsafe { self.data.get_unchecked(index as usize) }.store(0, Ordering::Relaxed);
-      return Some((get_redex_cont(redex), get_redex_host(redex)));
+      Some((get_redex_cont(redex), get_redex_host(redex)))
     } else {
-      return None;
+      None
     }
   }
 }

--- a/src/runtime/data/u60.rs
+++ b/src/runtime/data/u60.rs
@@ -4,95 +4,95 @@ type U60 = u64;
 
 #[inline(always)]
 pub fn new(a: u64) -> U60 {
-  return a & 0xFFF_FFFF_FFFF_FFFF;
+  a & 0xFFF_FFFF_FFFF_FFFF
 }
 
 #[inline(always)]
 pub fn val(a: u64) -> U60 {
-  return a;
+  a
 }
 
 #[inline(always)]
 pub fn add(a: U60, b: U60) -> U60 {
-  return new(a + b);
+  new(a + b)
 }
 
 #[inline(always)]
 pub fn sub(a: U60, b: U60) -> U60 {
-  return if a >= b { a - b } else { 0x1000000000000000 - (b - a) };
+  if a >= b { a - b } else { 0x1000000000000000 - (b - a) }
 }
 
 #[inline(always)]
 pub fn mul(a: U60, b: U60) -> U60 {
-  return new((a as u128 * b as u128) as u64);
+  new((a as u128 * b as u128) as u64)
 }
 
 #[inline(always)]
 pub fn div(a: U60, b: U60) -> U60 {
-  return a / b;
+  a / b
 }
 
 #[inline(always)]
 pub fn mdl(a: U60, b: U60) -> U60 {
-  return a % b;
+  a % b
 }
 
 #[inline(always)]
 pub fn and(a: U60, b: U60) -> U60 {
-  return a & b;
+  a & b
 }
 
 #[inline(always)]
 pub fn or(a: U60, b: U60) -> U60 {
-  return a | b;
+  a | b
 }
 
 #[inline(always)]
 pub fn xor(a: U60, b: U60) -> U60 {
-  return a ^ b;
+  a ^ b
 }
 
 #[inline(always)]
 pub fn shl(a: U60, b: U60) -> U60 {
-  return new(a << b);
+  new(a << b)
 }
 
 #[inline(always)]
 pub fn shr(a: U60, b: U60) -> U60 {
-  return a >> b;
+  a >> b
 }
 
 #[inline(always)]
 pub fn ltn(a: U60, b: U60) -> U60 {
-  return if a < b { 1 } else { 0 };
+  if a < b { 1 } else { 0 }
 }
 
 #[inline(always)]
 pub fn lte(a: U60, b: U60) -> U60 {
-  return if a <= b { 1 } else { 0 };
+  if a <= b { 1 } else { 0 }
 }
 
 #[inline(always)]
 pub fn eql(a: U60, b: U60) -> U60 {
-  return if a == b { 1 } else { 0 };
+  if a == b { 1 } else { 0 }
 }
 
 #[inline(always)]
 pub fn gte(a: U60, b: U60) -> U60 {
-  return if a >= b { 1 } else { 0 };
+  if a >= b { 1 } else { 0 }
 }
 
 #[inline(always)]
 pub fn gtn(a: U60, b: U60) -> U60 {
-  return if a > b { 1 } else { 0 };
+  if a > b { 1 } else { 0 }
 }
 
 #[inline(always)]
 pub fn neq(a: U60, b: U60) -> U60 {
-  return if a != b { 1 } else { 0 };
+  if a != b { 1 } else { 0 }
 }
 
 #[inline(always)]
 pub fn show(a: U60) -> String {
-  return format!("{}", a);
+  format!("{a}")
 }

--- a/src/runtime/data/u60.rs
+++ b/src/runtime/data/u60.rs
@@ -19,7 +19,11 @@ pub fn add(a: U60, b: U60) -> U60 {
 
 #[inline(always)]
 pub fn sub(a: U60, b: U60) -> U60 {
-  if a >= b { a - b } else { 0x1000000000000000 - (b - a) }
+  if a >= b {
+    a - b
+  } else {
+    0x1000000000000000 - (b - a)
+  }
 }
 
 #[inline(always)]
@@ -64,32 +68,56 @@ pub fn shr(a: U60, b: U60) -> U60 {
 
 #[inline(always)]
 pub fn ltn(a: U60, b: U60) -> U60 {
-  if a < b { 1 } else { 0 }
+  if a < b {
+    1
+  } else {
+    0
+  }
 }
 
 #[inline(always)]
 pub fn lte(a: U60, b: U60) -> U60 {
-  if a <= b { 1 } else { 0 }
+  if a <= b {
+    1
+  } else {
+    0
+  }
 }
 
 #[inline(always)]
 pub fn eql(a: U60, b: U60) -> U60 {
-  if a == b { 1 } else { 0 }
+  if a == b {
+    1
+  } else {
+    0
+  }
 }
 
 #[inline(always)]
 pub fn gte(a: U60, b: U60) -> U60 {
-  if a >= b { 1 } else { 0 }
+  if a >= b {
+    1
+  } else {
+    0
+  }
 }
 
 #[inline(always)]
 pub fn gtn(a: U60, b: U60) -> U60 {
-  if a > b { 1 } else { 0 }
+  if a > b {
+    1
+  } else {
+    0
+  }
 }
 
 #[inline(always)]
 pub fn neq(a: U60, b: U60) -> U60 {
-  if a != b { 1 } else { 0 }
+  if a != b {
+    1
+  } else {
+    0
+  }
 }
 
 #[inline(always)]

--- a/src/runtime/data/u60.rs
+++ b/src/runtime/data/u60.rs
@@ -68,56 +68,32 @@ pub fn shr(a: U60, b: U60) -> U60 {
 
 #[inline(always)]
 pub fn ltn(a: U60, b: U60) -> U60 {
-  if a < b {
-    1
-  } else {
-    0
-  }
+  u64::from(a < b)
 }
 
 #[inline(always)]
 pub fn lte(a: U60, b: U60) -> U60 {
-  if a <= b {
-    1
-  } else {
-    0
-  }
+  u64::from(a <= b)
 }
 
 #[inline(always)]
 pub fn eql(a: U60, b: U60) -> U60 {
-  if a == b {
-    1
-  } else {
-    0
-  }
+  u64::from(a == b)
 }
 
 #[inline(always)]
 pub fn gte(a: U60, b: U60) -> U60 {
-  if a >= b {
-    1
-  } else {
-    0
-  }
+  u64::from(a >= b)
 }
 
 #[inline(always)]
 pub fn gtn(a: U60, b: U60) -> U60 {
-  if a > b {
-    1
-  } else {
-    0
-  }
+  u64::from(a > b)
 }
 
 #[inline(always)]
 pub fn neq(a: U60, b: U60) -> U60 {
-  if a != b {
-    1
-  } else {
-    0
-  }
+  u64::from(a != b)
 }
 
 #[inline(always)]

--- a/src/runtime/data/u64_map.rs
+++ b/src/runtime/data/u64_map.rs
@@ -1,7 +1,7 @@
 // std::collections::HashMap<u64, A, std::hash::BuildHasherDefault<nohash_hasher::NoHashHasher<u64>>>;
 
 pub struct U64Map<A> {
-  pub data: Vec<Option<A>>
+  pub data: Vec<Option<A>>,
 }
 
 impl<A> U64Map<A> {
@@ -11,7 +11,7 @@ impl<A> U64Map<A> {
   }
 
   pub fn from_hashmap(old_map: &mut std::collections::HashMap<u64, A>) -> U64Map<A> {
-    let mut new_map : U64Map<A> = U64Map::new();
+    let mut new_map: U64Map<A> = U64Map::new();
     for (key, val) in old_map.drain() {
       new_map.insert(key, val);
     }

--- a/src/runtime/data/u64_map.rs
+++ b/src/runtime/data/u64_map.rs
@@ -7,7 +7,7 @@ pub struct U64Map<A> {
 impl<A> U64Map<A> {
   pub fn new() -> U64Map<A> {
     // std::collections::HashMap::with_hasher(std::hash::BuildHasherDefault::default());
-    return U64Map { data: Vec::new() };
+    U64Map { data: Vec::new() }
   }
 
   pub fn from_hashmap(old_map: &mut std::collections::HashMap<u64, A>) -> U64Map<A> {
@@ -15,13 +15,13 @@ impl<A> U64Map<A> {
     for (key, val) in old_map.drain() {
       new_map.insert(key, val);
     }
-    return new_map;
+    new_map
   }
 
   pub fn push(&mut self, val: A) -> u64 {
     let key = self.data.len() as u64;
     self.insert(key, val);
-    return key;
+    key
   }
 
   pub fn insert(&mut self, key: u64, val: A) {
@@ -35,6 +35,6 @@ impl<A> U64Map<A> {
     if let Some(Some(got)) = self.data.get(*key as usize) {
       return Some(got);
     }
-    return None;
+    None
   }
 }

--- a/src/runtime/data/u64_map.rs
+++ b/src/runtime/data/u64_map.rs
@@ -4,6 +4,12 @@ pub struct U64Map<A> {
   pub data: Vec<Option<A>>,
 }
 
+impl<A> Default for U64Map<A> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl<A> U64Map<A> {
   pub fn new() -> U64Map<A> {
     // std::collections::HashMap::with_hasher(std::hash::BuildHasherDefault::default());

--- a/src/runtime/data/visit_queue.rs
+++ b/src/runtime/data/visit_queue.rs
@@ -2,10 +2,10 @@
 // -----------
 // A concurrent task-stealing queue featuring push, pop and steal.
 
-use crossbeam::utils::{CachePadded};
+use crossbeam::utils::CachePadded;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
-pub const VISIT_QUEUE_SIZE : usize = 1 << 24;
+pub const VISIT_QUEUE_SIZE: usize = 1 << 24;
 
 // - 32 bits: host
 // - 32 bits: cont
@@ -26,7 +26,7 @@ pub fn get_visit_host(visit: Visit) -> u64 {
 }
 
 pub fn get_visit_hold(visit: Visit) -> bool {
-  return (visit >> 31) & 1 == 1; 
+  return (visit >> 31) & 1 == 1;
 }
 
 pub fn get_visit_cont(visit: Visit) -> u64 {
@@ -34,13 +34,12 @@ pub fn get_visit_cont(visit: Visit) -> u64 {
 }
 
 impl VisitQueue {
-
   pub fn new() -> VisitQueue {
     return VisitQueue {
       init: CachePadded::new(AtomicUsize::new(0)),
       last: CachePadded::new(AtomicUsize::new(0)),
       data: crate::runtime::new_atomic_u64_array(VISIT_QUEUE_SIZE),
-    }
+    };
   }
 
   pub fn push(&self, value: u64) {
@@ -72,12 +71,16 @@ impl VisitQueue {
     let index = self.init.load(Ordering::Relaxed);
     let visit = unsafe { self.data.get_unchecked(index) }.load(Ordering::Relaxed);
     if visit != 0 && !get_visit_hold(visit) {
-      if let Ok(visit) = unsafe { self.data.get_unchecked(index) }.compare_exchange(visit, 0, Ordering::Relaxed, Ordering::Relaxed) {
+      if let Ok(visit) = unsafe { self.data.get_unchecked(index) }.compare_exchange(
+        visit,
+        0,
+        Ordering::Relaxed,
+        Ordering::Relaxed,
+      ) {
         self.init.fetch_add(1, Ordering::Relaxed);
         return Some((get_visit_cont(visit), get_visit_host(visit)));
       }
     }
     return None;
   }
-
 }

--- a/src/runtime/data/visit_queue.rs
+++ b/src/runtime/data/visit_queue.rs
@@ -33,6 +33,12 @@ pub fn get_visit_cont(visit: Visit) -> u64 {
   visit & 0x3FFFFFF
 }
 
+impl Default for VisitQueue {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl VisitQueue {
   pub fn new() -> VisitQueue {
     VisitQueue {

--- a/src/runtime/data/visit_queue.rs
+++ b/src/runtime/data/visit_queue.rs
@@ -18,28 +18,28 @@ pub struct VisitQueue {
 }
 
 pub fn new_visit(host: u64, hold: bool, cont: u64) -> Visit {
-  return (host << 32) | (if hold { 0x80000000 } else { 0 }) | cont;
+  (host << 32) | (if hold { 0x80000000 } else { 0 }) | cont
 }
 
 pub fn get_visit_host(visit: Visit) -> u64 {
-  return visit >> 32;
+  visit >> 32
 }
 
 pub fn get_visit_hold(visit: Visit) -> bool {
-  return (visit >> 31) & 1 == 1;
+  (visit >> 31) & 1 == 1
 }
 
 pub fn get_visit_cont(visit: Visit) -> u64 {
-  return visit & 0x3FFFFFF;
+  visit & 0x3FFFFFF
 }
 
 impl VisitQueue {
   pub fn new() -> VisitQueue {
-    return VisitQueue {
+    VisitQueue {
       init: CachePadded::new(AtomicUsize::new(0)),
       last: CachePadded::new(AtomicUsize::new(0)),
       data: crate::runtime::new_atomic_u64_array(VISIT_QUEUE_SIZE),
-    };
+    }
   }
 
   pub fn push(&self, value: u64) {
@@ -81,6 +81,6 @@ impl VisitQueue {
         return Some((get_visit_cont(visit), get_visit_host(visit)));
       }
     }
-    return None;
+    None
   }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -26,12 +26,12 @@ pub fn default_heap_size() -> usize {
   let available_memory = System::new_with_specifics(RefreshKind::new().with_memory()).free_memory();
   let heap_size = (available_memory * 3 / 4) / 8;
   let heap_size = std::cmp::min(heap_size as usize, 16 * CELLS_PER_GB);
-  return heap_size as usize;
+  heap_size
 }
 
 // If unspecified, spawns 1 thread for each available core
 pub fn default_heap_tids() -> usize {
-  return std::thread::available_parallelism().unwrap().get();
+  std::thread::available_parallelism().unwrap().get()
 }
 
 pub struct Runtime {
@@ -50,7 +50,7 @@ impl Runtime {
       prog: Program::new(),
       book: language::rulebook::new_rulebook(),
       tids: new_tids(tids),
-      dbug: dbug,
+      dbug,
     }
   }
 
@@ -66,7 +66,7 @@ impl Runtime {
     let prog = Program::new();
     let book = language::rulebook::gen_rulebook(&file);
     let tids = new_tids(tids);
-    return Ok(Runtime { heap, prog, book, tids, dbug });
+    Ok(Runtime { heap, prog, book, tids, dbug })
   }
 
   ////fn get_area(&mut self) -> runtime::Area {
@@ -108,18 +108,18 @@ impl Runtime {
   pub fn normalize_code(&mut self, code: &str) -> u64 {
     let host = self.alloc_code(code).ok().unwrap();
     self.normalize(host);
-    return host;
+    host
   }
 
   /// Evaluates a code to normal form. Returns its location.
   pub fn eval_to_loc(&mut self, code: &str) -> u64 {
-    return self.normalize_code(code);
+    self.normalize_code(code)
   }
 
   /// Evaluates a code to normal form.
   pub fn eval(&mut self, code: &str) -> String {
     let host = self.normalize_code(code);
-    return self.show(host);
+    self.show(host)
   }
 
   //// /// Given a location, runs side-effective actions
@@ -161,219 +161,219 @@ impl Runtime {
   //// WASM re-exports
 
   pub fn DP0() -> u64 {
-    return DP0;
+    DP0
   }
 
   pub fn DP1() -> u64 {
-    return DP1;
+    DP1
   }
 
   pub fn VAR() -> u64 {
-    return VAR;
+    VAR
   }
 
   pub fn ARG() -> u64 {
-    return ARG;
+    ARG
   }
 
   pub fn ERA() -> u64 {
-    return ERA;
+    ERA
   }
 
   pub fn LAM() -> u64 {
-    return LAM;
+    LAM
   }
 
   pub fn APP() -> u64 {
-    return APP;
+    APP
   }
 
   pub fn SUP() -> u64 {
-    return SUP;
+    SUP
   }
 
   pub fn CTR() -> u64 {
-    return CTR;
+    CTR
   }
 
   pub fn FUN() -> u64 {
-    return FUN;
+    FUN
   }
 
   pub fn OP2() -> u64 {
-    return OP2;
+    OP2
   }
 
   pub fn U60() -> u64 {
-    return U60;
+    U60
   }
 
   pub fn F60() -> u64 {
-    return F60;
+    F60
   }
 
   pub fn ADD() -> u64 {
-    return ADD;
+    ADD
   }
 
   pub fn SUB() -> u64 {
-    return SUB;
+    SUB
   }
 
   pub fn MUL() -> u64 {
-    return MUL;
+    MUL
   }
 
   pub fn DIV() -> u64 {
-    return DIV;
+    DIV
   }
 
   pub fn MOD() -> u64 {
-    return MOD;
+    MOD
   }
 
   pub fn AND() -> u64 {
-    return AND;
+    AND
   }
 
   pub fn OR() -> u64 {
-    return OR;
+    OR
   }
 
   pub fn XOR() -> u64 {
-    return XOR;
+    XOR
   }
 
   pub fn SHL() -> u64 {
-    return SHL;
+    SHL
   }
 
   pub fn SHR() -> u64 {
-    return SHR;
+    SHR
   }
 
   pub fn LTN() -> u64 {
-    return LTN;
+    LTN
   }
 
   pub fn LTE() -> u64 {
-    return LTE;
+    LTE
   }
 
   pub fn EQL() -> u64 {
-    return EQL;
+    EQL
   }
 
   pub fn GTE() -> u64 {
-    return GTE;
+    GTE
   }
 
   pub fn GTN() -> u64 {
-    return GTN;
+    GTN
   }
 
   pub fn NEQ() -> u64 {
-    return NEQ;
+    NEQ
   }
 
   pub fn CELLS_PER_KB() -> usize {
-    return CELLS_PER_KB;
+    CELLS_PER_KB
   }
 
   pub fn CELLS_PER_MB() -> usize {
-    return CELLS_PER_MB;
+    CELLS_PER_MB
   }
 
   pub fn CELLS_PER_GB() -> usize {
-    return CELLS_PER_GB;
+    CELLS_PER_GB
   }
 
   pub fn get_tag(lnk: Ptr) -> u64 {
-    return get_tag(lnk);
+    get_tag(lnk)
   }
 
   pub fn get_ext(lnk: Ptr) -> u64 {
-    return get_ext(lnk);
+    get_ext(lnk)
   }
 
   pub fn get_val(lnk: Ptr) -> u64 {
-    return get_val(lnk);
+    get_val(lnk)
   }
 
   pub fn get_num(lnk: Ptr) -> u64 {
-    return get_num(lnk);
+    get_num(lnk)
   }
 
   pub fn get_loc(lnk: Ptr, arg: u64) -> u64 {
-    return get_loc(lnk, arg);
+    get_loc(lnk, arg)
   }
 
   pub fn Var(pos: u64) -> Ptr {
-    return Var(pos);
+    Var(pos)
   }
 
   pub fn Dp0(col: u64, pos: u64) -> Ptr {
-    return Dp0(col, pos);
+    Dp0(col, pos)
   }
 
   pub fn Dp1(col: u64, pos: u64) -> Ptr {
-    return Dp1(col, pos);
+    Dp1(col, pos)
   }
 
   pub fn Arg(pos: u64) -> Ptr {
-    return Arg(pos);
+    Arg(pos)
   }
 
   pub fn Era() -> Ptr {
-    return Era();
+    Era()
   }
 
   pub fn Lam(pos: u64) -> Ptr {
-    return Lam(pos);
+    Lam(pos)
   }
 
   pub fn App(pos: u64) -> Ptr {
-    return App(pos);
+    App(pos)
   }
 
   pub fn Sup(col: u64, pos: u64) -> Ptr {
-    return Sup(col, pos);
+    Sup(col, pos)
   }
 
   pub fn Op2(ope: u64, pos: u64) -> Ptr {
-    return Op2(ope, pos);
+    Op2(ope, pos)
   }
 
   pub fn U6O(val: u64) -> Ptr {
-    return U6O(val);
+    U6O(val)
   }
 
   pub fn F6O(val: u64) -> Ptr {
-    return F6O(val);
+    F6O(val)
   }
 
   pub fn Ctr(fun: u64, pos: u64) -> Ptr {
-    return Ctr(fun, pos);
+    Ctr(fun, pos)
   }
 
   pub fn Fun(fun: u64, pos: u64) -> Ptr {
-    return Fun(fun, pos);
+    Fun(fun, pos)
   }
 
   pub fn link(&mut self, loc: u64, lnk: Ptr) -> Ptr {
-    return link(&self.heap, loc, lnk);
+    link(&self.heap, loc, lnk)
   }
 
   pub fn alloc(&mut self, size: u64) -> u64 {
-    return alloc(&self.heap, 0, size); // FIXME tid?
+    alloc(&self.heap, 0, size) // FIXME tid?
   }
 
   pub fn free(&mut self, loc: u64, size: u64) {
-    return free(&self.heap, 0, loc, size); // FIXME tid?
+    free(&self.heap, 0, loc, size) // FIXME tid?
   }
 
   pub fn collect(&mut self, term: Ptr) {
-    return collect(&self.heap, &self.prog.aris, 0, term); // FIXME tid?
+    collect(&self.heap, &self.prog.aris, 0, term) // FIXME tid?
   }
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8,11 +8,11 @@ pub mod base;
 pub mod data;
 pub mod rule;
 
-use sysinfo::{System, SystemExt, RefreshKind};
+use sysinfo::{RefreshKind, System, SystemExt};
 
-pub use base::{*};
-pub use data::{*};
-pub use rule::{*};
+pub use base::*;
+pub use data::*;
+pub use rule::*;
 
 use crate::language;
 
@@ -43,7 +43,6 @@ pub struct Runtime {
 }
 
 impl Runtime {
-
   /// Creates a new, empty runtime
   pub fn new(size: usize, tids: usize, dbug: bool) -> Runtime {
     Runtime {
@@ -56,7 +55,12 @@ impl Runtime {
   }
 
   /// Creates a runtime from source code, given a max number of nodes
-  pub fn from_code_with(code: &str, size: usize, tids: usize, dbug: bool) -> Result<Runtime, String> {
+  pub fn from_code_with(
+    code: &str,
+    size: usize,
+    tids: usize,
+    dbug: bool,
+  ) -> Result<Runtime, String> {
     let file = language::syntax::read_file(code)?;
     let heap = new_heap(size, tids);
     let prog = Program::new();
@@ -66,7 +70,7 @@ impl Runtime {
   }
 
   ////fn get_area(&mut self) -> runtime::Area {
-    ////return runtime::get_area(&mut self.heap, 0)
+  ////return runtime::get_area(&mut self.heap, 0)
   ////}
 
   /// Creates a runtime from a source code
@@ -77,7 +81,7 @@ impl Runtime {
 
   ///// Extends a runtime with new definitions
   //pub fn define(&mut self, _code: &str) {
-    //todo!()
+  //todo!()
   //}
 
   /// Allocates a new term, returns its location
@@ -121,7 +125,7 @@ impl Runtime {
   //// /// Given a location, runs side-effective actions
   ////#[cfg(not(target_arch = "wasm32"))]
   ////pub fn run_io(&mut self, host: u64) {
-    ////runtime::run_io(&mut self.heap, &self.prog, &[0], host)
+  ////runtime::run_io(&mut self.heap, &self.prog, &[0], host)
   ////}
 
   /// Given a location, recovers the lambda Term stored on it, as code
@@ -155,7 +159,7 @@ impl Runtime {
   }
 
   //// WASM re-exports
-  
+
   pub fn DP0() -> u64 {
     return DP0;
   }
@@ -277,11 +281,11 @@ impl Runtime {
   }
 
   pub fn CELLS_PER_MB() -> usize {
-    return CELLS_PER_MB; 
+    return CELLS_PER_MB;
   }
 
   pub fn CELLS_PER_GB() -> usize {
-    return CELLS_PER_GB; 
+    return CELLS_PER_GB;
   }
 
   pub fn get_tag(lnk: Ptr) -> u64 {
@@ -371,7 +375,6 @@ impl Runtime {
   pub fn collect(&mut self, term: Ptr) {
     return collect(&self.heap, &self.prog.aris, 0, term); // FIXME tid?
   }
-
 }
 
 // Methods that aren't compiled to JS

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -25,8 +25,7 @@ pub fn default_heap_size() -> usize {
   use sysinfo::SystemExt;
   let available_memory = System::new_with_specifics(RefreshKind::new().with_memory()).free_memory();
   let heap_size = (available_memory * 3 / 4) / 8;
-  let heap_size = std::cmp::min(heap_size as usize, 16 * CELLS_PER_GB);
-  heap_size
+  std::cmp::min(heap_size as usize, 16 * CELLS_PER_GB)
 }
 
 // If unspecified, spawns 1 thread for each available core

--- a/src/runtime/rule/app.rs
+++ b/src/runtime/rule/app.rs
@@ -5,7 +5,7 @@ pub fn visit(ctx: ReduceCtx) -> bool {
   let goup = ctx.redex.insert(ctx.tid, new_redex(*ctx.host, *ctx.cont, 1));
   *ctx.cont = goup;
   *ctx.host = get_loc(ctx.term, 0);
-  return true;
+  true
 }
 
 #[inline(always)]
@@ -53,5 +53,5 @@ pub fn apply(ctx: ReduceCtx) -> bool {
     return false;
   }
 
-  return false;
+  false
 }

--- a/src/runtime/rule/app.rs
+++ b/src/runtime/rule/app.rs
@@ -1,4 +1,4 @@
-use crate::runtime::{*};
+use crate::runtime::*;
 
 #[inline(always)]
 pub fn visit(ctx: ReduceCtx) -> bool {
@@ -18,7 +18,13 @@ pub fn apply(ctx: ReduceCtx) -> bool {
   // body
   if get_tag(arg0) == LAM {
     inc_cost(ctx.heap, ctx.tid);
-    atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Var(get_loc(arg0, 0)), take_arg(ctx.heap, ctx.term, 1));
+    atomic_subst(
+      ctx.heap,
+      &ctx.prog.aris,
+      ctx.tid,
+      Var(get_loc(arg0, 0)),
+      take_arg(ctx.heap, ctx.term, 1),
+    );
     link(ctx.heap, *ctx.host, take_arg(ctx.heap, arg0, 1));
     free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 2);
     free(ctx.heap, ctx.tid, get_loc(arg0, 0), 2);

--- a/src/runtime/rule/dup.rs
+++ b/src/runtime/rule/dup.rs
@@ -1,4 +1,4 @@
-use crate::runtime::{*};
+use crate::runtime::*;
 
 #[inline(always)]
 pub fn visit(ctx: ReduceCtx) -> bool {
@@ -10,7 +10,6 @@ pub fn visit(ctx: ReduceCtx) -> bool {
 
 #[inline(always)]
 pub fn apply(ctx: ReduceCtx) -> bool {
-
   let arg0 = load_arg(ctx.heap, ctx.term, 2);
   let tcol = get_ext(ctx.term);
 
@@ -31,7 +30,13 @@ pub fn apply(ctx: ReduceCtx) -> bool {
     link(ctx.heap, par0 + 0, Var(lam0));
     link(ctx.heap, lam0 + 1, Dp0(get_ext(ctx.term), let0));
     link(ctx.heap, lam1 + 1, Dp1(get_ext(ctx.term), let0));
-    atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Var(get_loc(arg0, 0)), Sup(get_ext(ctx.term), par0));
+    atomic_subst(
+      ctx.heap,
+      &ctx.prog.aris,
+      ctx.tid,
+      Var(get_loc(arg0, 0)),
+      Sup(get_ext(ctx.term), par0),
+    );
     atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp0(tcol, get_loc(ctx.term, 0)), Lam(lam0));
     atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp1(tcol, get_loc(ctx.term, 0)), Lam(lam1));
     let done = Lam(if get_tag(ctx.term) == DP0 { lam0 } else { lam1 });
@@ -40,24 +45,33 @@ pub fn apply(ctx: ReduceCtx) -> bool {
     free(ctx.heap, ctx.tid, get_loc(arg0, 0), 2);
     return true;
   }
-
-  // dup x y = {a b}              
+  // dup x y = {a b}
   // --------------- DUP-SUP
-  // if equal: | else:        
-  // x <- a    | x <- {xA xB} 
-  // y <- b    | y <- {yA yB} 
+  // if equal: | else:
+  // x <- a    | x <- {xA xB}
+  // y <- b    | y <- {yA yB}
   //           | dup xA yA = a
   //           | dup xB yB = b
   else if get_tag(arg0) == SUP {
-
     if tcol == get_ext(arg0) {
       inc_cost(ctx.heap, ctx.tid);
-      atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp0(tcol, get_loc(ctx.term, 0)), take_arg(ctx.heap, arg0, 0));
-      atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp1(tcol, get_loc(ctx.term, 0)), take_arg(ctx.heap, arg0, 1));
+      atomic_subst(
+        ctx.heap,
+        &ctx.prog.aris,
+        ctx.tid,
+        Dp0(tcol, get_loc(ctx.term, 0)),
+        take_arg(ctx.heap, arg0, 0),
+      );
+      atomic_subst(
+        ctx.heap,
+        &ctx.prog.aris,
+        ctx.tid,
+        Dp1(tcol, get_loc(ctx.term, 0)),
+        take_arg(ctx.heap, arg0, 1),
+      );
       free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 3);
       free(ctx.heap, ctx.tid, get_loc(arg0, 0), 2);
       return true;
-
     } else {
       inc_cost(ctx.heap, ctx.tid);
       let par0 = alloc(ctx.heap, ctx.tid, 2);
@@ -70,13 +84,24 @@ pub fn apply(ctx: ReduceCtx) -> bool {
       link(ctx.heap, par1 + 1, Dp1(tcol, let1));
       link(ctx.heap, par0 + 0, Dp0(tcol, let0));
       link(ctx.heap, par0 + 1, Dp0(tcol, let1));
-      atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp0(tcol, get_loc(ctx.term, 0)), Sup(get_ext(arg0), par0));
-      atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp1(tcol, get_loc(ctx.term, 0)), Sup(get_ext(arg0), par1));
+      atomic_subst(
+        ctx.heap,
+        &ctx.prog.aris,
+        ctx.tid,
+        Dp0(tcol, get_loc(ctx.term, 0)),
+        Sup(get_ext(arg0), par0),
+      );
+      atomic_subst(
+        ctx.heap,
+        &ctx.prog.aris,
+        ctx.tid,
+        Dp1(tcol, get_loc(ctx.term, 0)),
+        Sup(get_ext(arg0), par1),
+      );
       free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 3);
       return true;
     }
   }
-
   // dup x y = N
   // ----------- DUP-U60
   // x <- N
@@ -89,7 +114,6 @@ pub fn apply(ctx: ReduceCtx) -> bool {
     free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 3);
     return true;
   }
-
   // dup x y = N
   // ----------- DUP-F60
   // x <- N
@@ -102,7 +126,6 @@ pub fn apply(ctx: ReduceCtx) -> bool {
     free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 3);
     return true;
   }
-
   // dup x y = (K a b c ...)
   // ----------------------- DUP-CTR
   // dup a0 a1 = a
@@ -116,14 +139,26 @@ pub fn apply(ctx: ReduceCtx) -> bool {
     let fnum = get_ext(arg0);
     let fari = arity_of(&ctx.prog.aris, arg0);
     if fari == 0 {
-      atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp0(tcol, get_loc(ctx.term, 0)), Ctr(fnum, 0));
-      atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp1(tcol, get_loc(ctx.term, 0)), Ctr(fnum, 0));
+      atomic_subst(
+        ctx.heap,
+        &ctx.prog.aris,
+        ctx.tid,
+        Dp0(tcol, get_loc(ctx.term, 0)),
+        Ctr(fnum, 0),
+      );
+      atomic_subst(
+        ctx.heap,
+        &ctx.prog.aris,
+        ctx.tid,
+        Dp1(tcol, get_loc(ctx.term, 0)),
+        Ctr(fnum, 0),
+      );
       link(ctx.heap, *ctx.host, Ctr(fnum, 0));
       free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 3);
     } else {
       let ctr0 = get_loc(arg0, 0);
       let ctr1 = alloc(ctx.heap, ctx.tid, fari);
-      for i in 0 .. fari - 1 {
+      for i in 0..fari - 1 {
         let leti = alloc(ctx.heap, ctx.tid, 3);
         link(ctx.heap, leti + 2, take_arg(ctx.heap, arg0, i));
         link(ctx.heap, ctr0 + i, Dp0(get_ext(ctx.term), leti));
@@ -133,13 +168,24 @@ pub fn apply(ctx: ReduceCtx) -> bool {
       link(ctx.heap, leti + 2, take_arg(ctx.heap, arg0, fari - 1));
       link(ctx.heap, ctr0 + fari - 1, Dp0(get_ext(ctx.term), leti));
       link(ctx.heap, ctr1 + fari - 1, Dp1(get_ext(ctx.term), leti));
-      atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp0(tcol, get_loc(ctx.term, 0)), Ctr(fnum, ctr0));
-      atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp1(tcol, get_loc(ctx.term, 0)), Ctr(fnum, ctr1));
+      atomic_subst(
+        ctx.heap,
+        &ctx.prog.aris,
+        ctx.tid,
+        Dp0(tcol, get_loc(ctx.term, 0)),
+        Ctr(fnum, ctr0),
+      );
+      atomic_subst(
+        ctx.heap,
+        &ctx.prog.aris,
+        ctx.tid,
+        Dp1(tcol, get_loc(ctx.term, 0)),
+        Ctr(fnum, ctr1),
+      );
       free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 3);
     }
     return true;
   }
-
   // dup x y = *
   // ----------- DUP-ERA
   // x <- *
@@ -151,9 +197,7 @@ pub fn apply(ctx: ReduceCtx) -> bool {
     link(ctx.heap, *ctx.host, Era());
     free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 3);
     return true;
-  }
-
-  else {
+  } else {
     return false;
   }
 }

--- a/src/runtime/rule/dup.rs
+++ b/src/runtime/rule/dup.rs
@@ -44,7 +44,7 @@ pub fn apply(ctx: ReduceCtx) -> bool {
     free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 3);
     free(ctx.heap, ctx.tid, get_loc(arg0, 0), 2);
     true
-  }
+
   // dup x y = {a b}
   // --------------- DUP-SUP
   // if equal: | else:
@@ -52,7 +52,7 @@ pub fn apply(ctx: ReduceCtx) -> bool {
   // y <- b    | y <- {yA yB}
   //           | dup xA yA = a
   //           | dup xB yB = b
-  else if get_tag(arg0) == SUP {
+  } else if get_tag(arg0) == SUP {
     if tcol == get_ext(arg0) {
       inc_cost(ctx.heap, ctx.tid);
       atomic_subst(
@@ -107,19 +107,13 @@ pub fn apply(ctx: ReduceCtx) -> bool {
   // x <- N
   // y <- N
   // ~
-  else if get_tag(arg0) == U60 {
-    inc_cost(ctx.heap, ctx.tid);
-    atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp0(tcol, get_loc(ctx.term, 0)), arg0);
-    atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp1(tcol, get_loc(ctx.term, 0)), arg0);
-    free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 3);
-    return true;
-  }
+  // ===== OR =====
   // dup x y = N
   // ----------- DUP-F60
   // x <- N
   // y <- N
   // ~
-  else if get_tag(arg0) == F60 {
+  else if get_tag(arg0) == U60 || get_tag(arg0) == F60 {
     inc_cost(ctx.heap, ctx.tid);
     atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp0(tcol, get_loc(ctx.term, 0)), arg0);
     atomic_subst(ctx.heap, &ctx.prog.aris, ctx.tid, Dp1(tcol, get_loc(ctx.term, 0)), arg0);

--- a/src/runtime/rule/dup.rs
+++ b/src/runtime/rule/dup.rs
@@ -5,7 +5,7 @@ pub fn visit(ctx: ReduceCtx) -> bool {
   let goup = ctx.redex.insert(ctx.tid, new_redex(*ctx.host, *ctx.cont, 1));
   *ctx.cont = goup;
   *ctx.host = get_loc(ctx.term, 2);
-  return true;
+  true
 }
 
 #[inline(always)]
@@ -43,7 +43,7 @@ pub fn apply(ctx: ReduceCtx) -> bool {
     link(ctx.heap, *ctx.host, done);
     free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), 3);
     free(ctx.heap, ctx.tid, get_loc(arg0, 0), 2);
-    return true;
+    true
   }
   // dup x y = {a b}
   // --------------- DUP-SUP

--- a/src/runtime/rule/fun.rs
+++ b/src/runtime/rule/fun.rs
@@ -1,5 +1,5 @@
-use crate::runtime::{*};
-use std::sync::atomic::{Ordering};
+use crate::runtime::*;
+use std::sync::atomic::Ordering;
 
 #[inline(always)]
 pub fn visit(ctx: ReduceCtx, sidxs: &[u64]) -> bool {
@@ -19,8 +19,12 @@ pub fn visit(ctx: ReduceCtx, sidxs: &[u64]) -> bool {
       return false;
     } else {
       let goup = ctx.redex.insert(ctx.tid, new_redex(*ctx.host, *ctx.cont, vlen as u64));
-      for i in 0 .. vlen - 1 {
-        ctx.visit.push(new_visit(unsafe { vbuf.get_unchecked(i).load(Ordering::Relaxed) }, ctx.hold, goup));
+      for i in 0..vlen - 1 {
+        ctx.visit.push(new_visit(
+          unsafe { vbuf.get_unchecked(i).load(Ordering::Relaxed) },
+          ctx.hold,
+          goup,
+        ));
       }
       *ctx.cont = goup;
       *ctx.host = unsafe { vbuf.get_unchecked(vlen - 1).load(Ordering::Relaxed) };
@@ -30,19 +34,19 @@ pub fn visit(ctx: ReduceCtx, sidxs: &[u64]) -> bool {
   //OLD_VISITER:
   //let len = sidxs.len() as u64;
   //if len == 0 {
-    //return false;
+  //return false;
   //} else {
-    //let goup = ctx.redex.insert(ctx.tid, new_redex(*ctx.host, *ctx.cont, sidxs.len() as u64));
-    //for (i, arg_idx) in sidxs.iter().enumerate() {
-      //if i < sidxs.len() - 1 {
-        //ctx.visit.push(new_visit(get_loc(ctx.term, *arg_idx), goup));
-      //} else {
-        //*ctx.cont = goup;
-        //*ctx.host = get_loc(ctx.term, *arg_idx);
-        //return true;
-      //}
-    //}
-    //return true;
+  //let goup = ctx.redex.insert(ctx.tid, new_redex(*ctx.host, *ctx.cont, sidxs.len() as u64));
+  //for (i, arg_idx) in sidxs.iter().enumerate() {
+  //if i < sidxs.len() - 1 {
+  //ctx.visit.push(new_visit(get_loc(ctx.term, *arg_idx), goup));
+  //} else {
+  //*ctx.cont = goup;
+  //*ctx.host = get_loc(ctx.term, *arg_idx);
+  //return true;
+  //}
+  //}
+  //return true;
   //}
 }
 
@@ -52,7 +56,15 @@ pub fn apply(ctx: ReduceCtx, fid: u64, visit: &VisitObj, apply: &ApplyObj) -> bo
   for (n, is_strict) in visit.strict_map.iter().enumerate() {
     let n = n as u64;
     if *is_strict && get_tag(load_arg(ctx.heap, ctx.term, n)) == SUP {
-      superpose(ctx.heap, &ctx.prog.aris, ctx.tid, *ctx.host, ctx.term, load_arg(ctx.heap, ctx.term, n), n);
+      superpose(
+        ctx.heap,
+        &ctx.prog.aris,
+        ctx.tid,
+        *ctx.host,
+        ctx.term,
+        load_arg(ctx.heap, ctx.term, n),
+        n,
+      );
       return true;
     }
   }
@@ -62,7 +74,7 @@ pub fn apply(ctx: ReduceCtx, fid: u64, visit: &VisitObj, apply: &ApplyObj) -> bo
   for (r, rule) in apply.rules.iter().enumerate() {
     // Check if the rule matches
     matched = true;
-    
+
     // Tests each rule condition (ex: `get_tag(args[0]) == SUCC`)
     for (i, cond) in rule.cond.iter().enumerate() {
       let i = i as u64;
@@ -85,23 +97,18 @@ pub fn apply(ctx: ReduceCtx, fid: u64, visit: &VisitObj, apply: &ApplyObj) -> bo
         VAR => {
           // If this is a strict argument, then we're in a default variable
           if unsafe { *visit.strict_map.get_unchecked(i as usize) } {
-
             // This is a Kind2-specific optimization.
             if rule.hoas && r != apply.rules.len() - 1 {
-
               // Matches number literals
-              let is_num
-                =  get_tag(load_arg(ctx.heap, ctx.term, i)) == U60
+              let is_num = get_tag(load_arg(ctx.heap, ctx.term, i)) == U60
                 || get_tag(load_arg(ctx.heap, ctx.term, i)) == F60;
 
               // Matches constructor labels
-              let is_ctr
-                =  get_tag(load_arg(ctx.heap, ctx.term, i)) == CTR
+              let is_ctr = get_tag(load_arg(ctx.heap, ctx.term, i)) == CTR
                 && arity_of(&ctx.prog.aris, load_arg(ctx.heap, ctx.term, i)) == 0;
 
               // Matches HOAS numbers and constructors
-              let is_hoas_ctr_num
-                =  get_tag(load_arg(ctx.heap, ctx.term, i)) == CTR
+              let is_hoas_ctr_num = get_tag(load_arg(ctx.heap, ctx.term, i)) == CTR
                 && get_ext(load_arg(ctx.heap, ctx.term, i)) >= KIND_TERM_CT0
                 && get_ext(load_arg(ctx.heap, ctx.term, i)) <= KIND_TERM_F60;
 
@@ -152,14 +159,22 @@ pub fn apply(ctx: ReduceCtx, fid: u64, visit: &VisitObj, apply: &ApplyObj) -> bo
 }
 
 #[inline(always)]
-pub fn superpose(heap: &Heap, aris: &Aris, tid: usize, host: u64, term: Ptr, argn: Ptr, n: u64) -> Ptr {
+pub fn superpose(
+  heap: &Heap,
+  aris: &Aris,
+  tid: usize,
+  host: u64,
+  term: Ptr,
+  argn: Ptr,
+  n: u64,
+) -> Ptr {
   inc_cost(heap, tid);
   let arit = arity_of(aris, term);
   let func = get_ext(term);
   let fun0 = get_loc(term, 0);
   let fun1 = alloc(heap, tid, arit);
   let par0 = get_loc(argn, 0);
-  for i in 0 .. arit {
+  for i in 0..arit {
     if i != n {
       let leti = alloc(heap, tid, 3);
       let argi = take_arg(heap, term, i);

--- a/src/runtime/rule/fun.rs
+++ b/src/runtime/rule/fun.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::Ordering;
 pub fn visit(ctx: ReduceCtx, sidxs: &[u64]) -> bool {
   let len = sidxs.len() as u64;
   if len == 0 {
-    return false;
+    false
   } else {
     let mut vlen = 0;
     let vbuf = unsafe { ctx.heap.vbuf.get_unchecked(ctx.tid) };
@@ -16,7 +16,7 @@ pub fn visit(ctx: ReduceCtx, sidxs: &[u64]) -> bool {
       }
     }
     if vlen == 0 {
-      return false;
+      false
     } else {
       let goup = ctx.redex.insert(ctx.tid, new_redex(*ctx.host, *ctx.cont, vlen as u64));
       for i in 0..vlen - 1 {
@@ -28,7 +28,7 @@ pub fn visit(ctx: ReduceCtx, sidxs: &[u64]) -> bool {
       }
       *ctx.cont = goup;
       *ctx.host = unsafe { vbuf.get_unchecked(vlen - 1).load(Ordering::Relaxed) };
-      return true;
+      true
     }
   }
   //OLD_VISITER:
@@ -147,7 +147,7 @@ pub fn apply(ctx: ReduceCtx, fid: u64, visit: &VisitObj, apply: &ApplyObj) -> bo
 
       // free the matched ctrs
       for (i, arity) in &rule.free {
-        free(ctx.heap, ctx.tid, get_loc(load_arg(ctx.heap, ctx.term, *i as u64), 0), *arity);
+        free(ctx.heap, ctx.tid, get_loc(load_arg(ctx.heap, ctx.term, *i), 0), *arity);
       }
       free(ctx.heap, ctx.tid, get_loc(ctx.term, 0), arity_of(&ctx.prog.aris, fid));
 
@@ -155,7 +155,7 @@ pub fn apply(ctx: ReduceCtx, fid: u64, visit: &VisitObj, apply: &ApplyObj) -> bo
     }
   }
 
-  return false;
+  false
 }
 
 #[inline(always)]

--- a/src/runtime/rule/mod.rs
+++ b/src/runtime/rule/mod.rs
@@ -1,4 +1,4 @@
 pub mod app;
 pub mod dup;
-pub mod op2;
 pub mod fun;
+pub mod op2;

--- a/src/runtime/rule/op2.rs
+++ b/src/runtime/rule/op2.rs
@@ -1,4 +1,4 @@
-use crate::runtime::{*};
+use crate::runtime::*;
 
 #[inline(always)]
 pub fn visit(ctx: ReduceCtx) -> bool {
@@ -30,7 +30,7 @@ pub fn apply(ctx: ReduceCtx) -> bool {
       DIV => u60::div(a, b),
       MOD => u60::mdl(a, b),
       AND => u60::and(a, b),
-      OR  => u60::or(a, b),
+      OR => u60::or(a, b),
       XOR => u60::xor(a, b),
       SHL => u60::shl(a, b),
       SHR => u60::shr(a, b),
@@ -40,7 +40,7 @@ pub fn apply(ctx: ReduceCtx) -> bool {
       GTE => u60::gte(a, b),
       GTN => u60::gtn(a, b),
       NEQ => u60::neq(a, b),
-      _   => 0,
+      _ => 0,
     };
     let done = U6O(c);
     link(ctx.heap, *ctx.host, done);
@@ -48,7 +48,6 @@ pub fn apply(ctx: ReduceCtx) -> bool {
 
     return false;
   }
-
   // (OP a b)
   // -------- OP2-F60
   // op(a, b)
@@ -65,7 +64,7 @@ pub fn apply(ctx: ReduceCtx) -> bool {
       DIV => f60::div(a, b),
       MOD => f60::mdl(a, b),
       AND => f60::and(a, b),
-      OR  => f60::or(a, b),
+      OR => f60::or(a, b),
       XOR => f60::xor(a, b),
       SHL => f60::shl(a, b),
       SHR => f60::shr(a, b),
@@ -75,7 +74,7 @@ pub fn apply(ctx: ReduceCtx) -> bool {
       GTE => f60::gte(a, b),
       GTN => f60::gtn(a, b),
       NEQ => f60::neq(a, b),
-      _   => 0,
+      _ => 0,
     };
     let done = F6O(c);
     link(ctx.heap, *ctx.host, done);
@@ -83,7 +82,6 @@ pub fn apply(ctx: ReduceCtx) -> bool {
 
     return false;
   }
-
   // (+ {a0 a1} b)
   // --------------------- OP2-SUP-0
   // dup b0 b1 = b
@@ -105,7 +103,6 @@ pub fn apply(ctx: ReduceCtx) -> bool {
     link(ctx.heap, *ctx.host, done);
     return false;
   }
-
   // (+ a {b0 b1})
   // --------------- OP2-SUP-1
   // dup a0 a1 = a

--- a/src/runtime/rule/op2.rs
+++ b/src/runtime/rule/op2.rs
@@ -6,7 +6,7 @@ pub fn visit(ctx: ReduceCtx) -> bool {
   ctx.visit.push(new_visit(get_loc(ctx.term, 1), ctx.hold, goup));
   *ctx.cont = goup;
   *ctx.host = get_loc(ctx.term, 0);
-  return true;
+  true
 }
 
 #[inline(always)]
@@ -125,5 +125,5 @@ pub fn apply(ctx: ReduceCtx) -> bool {
     return false;
   }
 
-  return false;
+  false
 }


### PR DESCRIPTION
Depends on #201 to avoid merge conflicts. I'll rebase this after that is merged.

---

This makes hvm compile on stable Rust! The annoying part is that we must manually identify which rust platforms have their integer sizes exactly equal to their alignment. Since the `target_has_atomic_equal_alignment` cfg check is unstable, we have to create our own equivalent, which works by whitelisting platforms where we know that the `u8` and `u64` sizes are of the alignments `8` and `64`.

This is easy to validate by looking at the [data layout](https://llvm.org/docs/LangRef.html#data-layout) of the target ( see [here](https://users.rust-lang.org/t/is-there-a-way-to-emulate-atomic-alignment-cfg-check-on-stable/87863/3?u=zicklag) ), so it's not that big a deal, we will just have to whitelist all supported platforms that people need to build for.