### PR TITLE
fix: remove unused argument from hello world example.

### DIFF
--- a/examples/hello/main.hvm
+++ b/examples/hello/main.hvm
@@ -1,3 +1,3 @@
 // HVM's "Hello, world!" is just a string!
 
-(Main n) = "Hello, world!"
+Main = "Hello, world!"


### PR DESCRIPTION
This helps prevent users from running into the confusing message: "Inconsistent arity on: '(Main *)'" because they didn't pass an argument to `hvm run -f hello/main.hvm`.