### PR TITLE
fix: correctly render superposed strings.

### DIFF
--- a/src/language/readback.rs
+++ b/src/language/readback.rs
@@ -482,6 +482,9 @@ pub fn as_string(heap: &Heap, prog: &Program, tids: &[usize], host: u64) -> Opti
         }
       }
       return None;
+    } else if runtime::get_tag(term) == runtime::SUP {
+      host = runtime::get_loc(term, 0);
+      continue;
     } else {
       return None;
     }


### PR DESCRIPTION
Previously, superpositions of strings were not rendering as strings. This causes issues when you try to open a file or print a string that happens to be superpositioned.

This fixes it so that superpositioned strings are rendered correctly as strings.

I learned a little bit about HVM, and the fix was surprisingly easy!

I'm not sure if my understanding that the first value of a SUP pointer will always point to the value that is to be cloned is correct, or of the second value could potentially be the value to be cloned, and the first value might be a variable pointer.

If I got it wrong, then we'll need to check both the first and the second value to see if either one is a string.