### PR TITLE
fix: remove `feature(atomic_mut_ptr)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(atomic_from_mut)]
-#![feature(atomic_mut_ptr)]
 
 #![allow(unused_variables)]
 #![allow(dead_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 #![feature(atomic_from_mut)]
-#![feature(atomic_mut_ptr)]
 
 #![allow(unused_variables)]
 #![allow(dead_code)]


### PR DESCRIPTION
The atomic_mut_ptr feature was merged! Now we don't need to specify it.

This requires the latest nightly to compile, and also fixes compilation on the latest nightly.