### PR TITLE
change `Runtime` API and add helper methods for constructing terms

### DIFF
--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -1,6 +1,7 @@
 use HOPA;
 use crate::runtime::data::u60;
 use crate::runtime::data::f60;
+use std::convert::{TryFrom, TryInto};
 
 // Types
 // =====
@@ -323,6 +324,78 @@ impl Term {
                 }))
             }
             _ => None,
+        }
+    }
+}
+
+impl From<u64> for Term {
+    fn from(value: u64) -> Self {
+        Self::integer(value)
+    }
+}
+
+impl From<f64> for Term {
+    fn from(value: f64) -> Self {
+        Self::float(value)
+    }
+}
+
+impl From<char> for Term {
+    fn from(value: char) -> Self {
+        Self::integer(value as u64)
+    }
+}
+
+impl From<String> for Term {
+    fn from(value: String) -> Self {
+        Self::string(value)
+    }
+}
+
+impl TryFrom<Term> for u64 {
+    type Error = Term;
+
+    fn try_from(value: Term) -> Result<Self, Self::Error> {
+        if let Some(num) = Term::as_integer(&value) {
+            Ok(num)
+        } else {
+            Err(value)
+        }
+    }
+}
+
+impl TryFrom<Term> for f64 {
+    type Error = Term;
+
+    fn try_from(value: Term) -> Result<Self, Self::Error> {
+        if let Some(num) = Term::as_float(&value) {
+            Ok(num)
+        } else {
+            Err(value)
+        }
+    }
+}
+
+impl TryFrom<Term> for char {
+    type Error = Term;
+
+    fn try_from(value: Term) -> Result<Self, Self::Error> {
+        if let Some(chr) = Term::as_char(&value) {
+            Ok(chr)
+        } else {
+            Err(value)
+        }
+    }
+}
+
+impl TryFrom<Term> for String {
+    type Error = Term;
+
+    fn try_from(value: Term) -> Result<Self, Self::Error> {
+        if let Some(string) = Term::as_string(&value) {
+            Ok(string)
+        } else {
+            Err(value)
         }
     }
 }

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -356,7 +356,7 @@ impl TryFrom<Term> for u64 {
     type Error = Term;
 
     fn try_from(value: Term) -> Result<Self, Self::Error> {
-        if let Some(num) = Term::as_integer(&value) {
+        if let Some(num) = value.as_integer() {
             Ok(num)
         } else {
             Err(value)
@@ -368,7 +368,7 @@ impl TryFrom<Term> for f64 {
     type Error = Term;
 
     fn try_from(value: Term) -> Result<Self, Self::Error> {
-        if let Some(num) = Term::as_float(&value) {
+        if let Some(num) = value.as_float() {
             Ok(num)
         } else {
             Err(value)
@@ -380,7 +380,7 @@ impl TryFrom<Term> for char {
     type Error = Term;
 
     fn try_from(value: Term) -> Result<Self, Self::Error> {
-        if let Some(chr) = Term::as_char(&value) {
+        if let Some(chr) = value.as_char() {
             Ok(chr)
         } else {
             Err(value)
@@ -392,7 +392,7 @@ impl TryFrom<Term> for String {
     type Error = Term;
 
     fn try_from(value: Term) -> Result<Self, Self::Error> {
-        if let Some(string) = Term::as_string(&value) {
+        if let Some(string) = value.as_string() {
             Ok(string)
         } else {
             Err(value)

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -225,6 +225,24 @@ impl Term {
         }
     }
 
+    /// returns a term representing the expression `{val0 val1}`,
+    pub fn superposition(val0: Self, val1: Self) -> Self {
+        Self::Sup {
+            val0: Box::new(val0),
+            val1: Box::new(val1),
+        }
+    }
+
+    /// returns a term representing the expression `dup copy0 copy1 = expr body`
+    pub fn duplication(copy0: impl Into<String>, copy1: impl Into<String>, expr: Self, body: Self) -> Self {
+        Self::Dup {
+            nam0: copy0.into(),
+            nam1: copy1.into(),
+            expr: Box::new(expr),
+            body: Box::new(body),
+        }
+    }
+
     /// returns a term representing the expression `if cond { expr } else { alt }`
     pub fn if_expression(cond: Self, expr: Self, alt: Self) -> Self {
         Self::constructor("U60.if", [cond, expr, alt])

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -9,7 +9,7 @@ use std::convert::{TryFrom, TryInto};
 // Term
 // ----
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Term {
   Var { name: String }, // TODO: add `global: bool`
   Dup { nam0: String, nam1: String, expr: Box<Term>, body: Box<Term> },

--- a/src/language/syntax.rs
+++ b/src/language/syntax.rs
@@ -301,6 +301,30 @@ impl Term {
             }
         }
     }
+
+    /// returns an iterator over the list represented by the term if it represents one
+    /// returns None otherwise.
+    ///
+    /// improper lists, i.e. those of the form `List.cons a b` where `b` is not a list,
+    /// terminate after `a`.
+    pub fn as_list(&self) -> Option<impl Iterator<Item=&Term>> {
+        match self {
+            Self::Ctr { name, args } if (name == "List.cons" || name == "List.nil") => {
+                let mut current_term = Some(self);
+                Some(std::iter::from_fn(move || {
+                    match current_term {
+                        Some(Self::Ctr { name, args }) if name == "List.cons" => {
+                            let elem = args.get(0).map(|x| x as &Self);
+                            current_term = args.get(1).map(|x| x as &Self);
+                            elem
+                        }
+                        _ => None,
+                    }
+                }))
+            }
+            _ => None,
+        }
+    }
 }
 
 // Rule

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,23 @@
 #![allow(unused_labels)]
 #![allow(non_upper_case_globals)]
 
+//! Higher-order Virtual Machine (HVM) is a pure functional runtime based on symmetric interaction combinators.
+//!
+//! to evaluate HVM source code, you can use [`Runtime`] as follows:
+//!
+//! ```
+//! # fn main() -> Result<(), String> {
+//! let code = "(Fib 0) = 0
+//! (Fib 1) = 1
+//! (Fib n) = (+ (Fib (- n 1)) (Fib (- n 2)))";
+//! let runtime = hvm::RuntimeBuilder::default().add_code(code)?.build();
+//! let term = hvm::syntax::read_term("(Fib 8)")?;
+//! let output = runtime.normalize_term(&term).as_integer();
+//! assert_eq!(Some(21), output);
+//! # Ok(())
+//! # }
+//! ```
+
 pub mod language;
 pub mod runtime;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@
 //! (Fib n) = (+ (Fib (- n 1)) (Fib (- n 2)))";
 //! let runtime = hvm::RuntimeBuilder::default().add_code(code)?.build();
 //! let term = hvm::syntax::read_term("(Fib 8)")?;
-//! let output = runtime.normalize_term(&term).as_integer();
-//! assert_eq!(Some(21), output);
+//! let output = runtime.eval_term(&term);
+//! assert_eq!(Ok(21), output);
 //! # Ok(())
 //! # }
 //! ```

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -68,13 +68,13 @@ impl Default for RuntimeBuilder {
 }
 
 impl RuntimeBuilder {
-    /// add a HVM rule to be interpreted by the runtime
+    /// add a HVM rule to be interpreted by the runtime.
     pub fn add_rule(mut self, rule: language::syntax::Rule) -> Self {
         self.rules.push(rule);
         self
     }
 
-    /// add multiple HVM rules at once
+    /// add multiple HVM rules to the runtime at once.
     pub fn add_rules(mut self, rules: impl IntoIterator<Item = language::syntax::Rule>) -> Self {
         self.rules.extend(rules.into_iter());
         self
@@ -105,7 +105,7 @@ impl RuntimeBuilder {
     /// add a function, prepared a head of time, which will be mapped to the given symbol
     ///
     /// allows precompilation of frequently used functions,
-    /// and including functionality that is not part of HVM by default, such as IO
+    /// and including functionality that is not part of HVM by default, such as IO.
     pub fn add_function(mut self, name: String, func: Function) -> Self {
         self.functions.insert(name, func);
         self
@@ -121,7 +121,7 @@ impl RuntimeBuilder {
     /// given in the number of terms that can be stored on the heap.
     ///
     /// use [`CELLS_PER_KB`], [`CELLS_PER_MB`] and [`CELLS_PER_GB`],
-    /// to add values in terms of memory size.
+    /// to choose values in terms of memory size.
     pub fn set_heap_size(mut self, heap_size: usize) -> Self {
         self.heap_size = heap_size;
         self
@@ -134,6 +134,7 @@ impl RuntimeBuilder {
         self
     }
 
+    /// builds a runtime with the configuration given to the builder.
     pub fn build(self) -> Runtime {
         let file = language::syntax::File {
             rules: self.rules,
@@ -169,9 +170,10 @@ impl RuntimeBuilder {
 }
 
 impl Runtime {
-    /// reduces the term to Normal Form,
-    /// meaning that applications in the term are evaluated,
-    /// untill there are no more applications in the term.
+    /// reduces the given term to Normal Form.
+    ///
+    /// this means that applications in the term are evaluated,
+    /// until there are no more applications in the term.
     pub fn normalize_term(&self, term: &language::syntax::Term) -> language::syntax::Term {
         let tid = 0;
 
@@ -191,8 +193,10 @@ impl Runtime {
         *output
     }
 
-    /// attempts to reduce the given term to the target type if possible.
-    /// on failure returns the error produced in the conversion of the reduced term.
+    /// attempts to evaluate the given term to the target type if possible.
+    ///
+    /// this is done by normalizing the term, and then attempting to convert the output.
+    /// on failure returns the error produced in the conversion.
     pub fn eval_term<T, E>(&self, term: &language::syntax::Term) -> Result<T, E>
     where language::syntax::Term: TryInto<T, Error=E> {
         self.normalize_term(term).try_into()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -190,4 +190,12 @@ impl Runtime {
         collect(&self.heap, &self.program.aris, tid, ptr);
         *output
     }
+
+    /// returns the number graph rewrites made by the runtime,
+    /// since its initialization.
+    ///
+    /// this serves as a measure of the computational cost of normalizing terms.
+    pub fn get_rewrite_count(&self) -> usize {
+        get_cost(&self.heap) as _
+    }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8,6 +8,7 @@ pub mod base;
 pub mod data;
 pub mod rule;
 
+use std::collections::HashMap;
 use sysinfo::{System, SystemExt, RefreshKind};
 
 pub use base::{*};
@@ -34,360 +35,173 @@ pub fn default_heap_tids() -> usize {
   return std::thread::available_parallelism().unwrap().get();
 }
 
+/// a builder for Runtime to determine its configuration
+pub struct RuntimeBuilder {
+    rules: Vec<language::syntax::Rule>,
+    strictness_maps: HashMap<String, Vec<bool>>,
+    functions: HashMap<String, Function>,
+    thread_count: usize,
+    heap_size: usize,
+    debug: bool,
+}
+
+/// the runtime which evaluates the HVM code
 pub struct Runtime {
-  pub heap: Heap,
-  pub prog: Program,
-  pub book: language::rulebook::RuleBook,
-  pub tids: Box<[usize]>,
-  pub dbug: bool,
+    heap: Heap,
+    program: Program,
+    book: language::rulebook::RuleBook,
+    thread_ids: Box<[usize]>,
+    debug: bool,
 }
 
-impl Runtime {
-
-  /// Creates a new, empty runtime
-  pub fn new(size: usize, tids: usize, dbug: bool) -> Runtime {
-    Runtime {
-      heap: new_heap(size, tids),
-      prog: Program::new(),
-      book: language::rulebook::new_rulebook(),
-      tids: new_tids(tids),
-      dbug: dbug,
+impl Default for RuntimeBuilder {
+    fn default() -> Self {
+        Self {
+            rules: Default::default(),
+            strictness_maps: Default::default(),
+            functions: Default::default(),
+            thread_count: default_heap_tids(),
+            heap_size: default_heap_size(),
+            debug: false,
+        }
     }
-  }
-
-  /// Creates a runtime from source code, given a max number of nodes
-  pub fn from_code_with(code: &str, size: usize, tids: usize, dbug: bool) -> Result<Runtime, String> {
-    let file = language::syntax::read_file(code)?;
-    let heap = new_heap(size, tids);
-    let prog = Program::new();
-    let book = language::rulebook::gen_rulebook(&file);
-    let tids = new_tids(tids);
-    return Ok(Runtime { heap, prog, book, tids, dbug });
-  }
-
-  ////fn get_area(&mut self) -> runtime::Area {
-    ////return runtime::get_area(&mut self.heap, 0)
-  ////}
-
-  /// Creates a runtime from a source code
-  //#[cfg(not(target_arch = "wasm32"))]
-  pub fn from_code(code: &str) -> Result<Runtime, String> {
-    Runtime::from_code_with(code, default_heap_size(), default_heap_tids(), false)
-  }
-
-  ///// Extends a runtime with new definitions
-  //pub fn define(&mut self, _code: &str) {
-    //todo!()
-  //}
-
-  /// Allocates a new term, returns its location
-  pub fn alloc_code(&mut self, code: &str) -> Result<u64, String> {
-    Ok(self.alloc_term(&*language::syntax::read_term(code)?))
-  }
-
-  /// Given a location, returns the pointer stored on it
-  pub fn load_ptr(&self, host: u64) -> Ptr {
-    load_ptr(&self.heap, host)
-  }
-
-  /// Given a location, evaluates a term to head normal form
-  pub fn reduce(&mut self, host: u64) {
-    reduce(&self.heap, &self.prog, &self.tids, host, false, self.dbug);
-  }
-
-  /// Given a location, evaluates a term to full normal form
-  pub fn normalize(&mut self, host: u64) {
-    reduce(&self.heap, &self.prog, &self.tids, host, true, self.dbug);
-  }
-
-  /// Evaluates a code, allocs and evaluates to full normal form. Returns its location.
-  pub fn normalize_code(&mut self, code: &str) -> u64 {
-    let host = self.alloc_code(code).ok().unwrap();
-    self.normalize(host);
-    return host;
-  }
-
-  /// Evaluates a code to normal form. Returns its location.
-  pub fn eval_to_loc(&mut self, code: &str) -> u64 {
-    return self.normalize_code(code);
-  }
-
-  /// Evaluates a code to normal form.
-  pub fn eval(&mut self, code: &str) -> String {
-    let host = self.normalize_code(code);
-    return self.show(host);
-  }
-
-  //// /// Given a location, runs side-effective actions
-  ////#[cfg(not(target_arch = "wasm32"))]
-  ////pub fn run_io(&mut self, host: u64) {
-    ////runtime::run_io(&mut self.heap, &self.prog, &[0], host)
-  ////}
-
-  /// Given a location, recovers the lambda Term stored on it, as code
-  pub fn show(&self, host: u64) -> String {
-    language::readback::as_code(&self.heap, &self.prog, host)
-  }
-
-  /// Given a location, recovers the linear Term stored on it, as code
-  pub fn show_linear(&self, host: u64) -> String {
-    language::readback::as_linear_code(&self.heap, &self.prog, host)
-  }
-
-  /// Return the total number of graph rewrites computed
-  pub fn get_rewrites(&self) -> u64 {
-    get_cost(&self.heap)
-  }
-
-  /// Returns the name of a given id
-  pub fn get_name(&self, id: u64) -> String {
-    self.prog.nams.get(&id).unwrap_or(&"?".to_string()).clone()
-  }
-
-  /// Returns the arity of a given id
-  pub fn get_arity(&self, id: u64) -> u64 {
-    *self.prog.aris.get(&id).unwrap_or(&u64::MAX)
-  }
-
-  /// Returns the name of a given id
-  pub fn get_id(&self, name: &str) -> u64 {
-    *self.book.name_to_id.get(name).unwrap_or(&u64::MAX)
-  }
-
-  //// WASM re-exports
-  
-  pub fn DP0() -> u64 {
-    return DP0;
-  }
-
-  pub fn DP1() -> u64 {
-    return DP1;
-  }
-
-  pub fn VAR() -> u64 {
-    return VAR;
-  }
-
-  pub fn ARG() -> u64 {
-    return ARG;
-  }
-
-  pub fn ERA() -> u64 {
-    return ERA;
-  }
-
-  pub fn LAM() -> u64 {
-    return LAM;
-  }
-
-  pub fn APP() -> u64 {
-    return APP;
-  }
-
-  pub fn SUP() -> u64 {
-    return SUP;
-  }
-
-  pub fn CTR() -> u64 {
-    return CTR;
-  }
-
-  pub fn FUN() -> u64 {
-    return FUN;
-  }
-
-  pub fn OP2() -> u64 {
-    return OP2;
-  }
-
-  pub fn U60() -> u64 {
-    return U60;
-  }
-
-  pub fn F60() -> u64 {
-    return F60;
-  }
-
-  pub fn ADD() -> u64 {
-    return ADD;
-  }
-
-  pub fn SUB() -> u64 {
-    return SUB;
-  }
-
-  pub fn MUL() -> u64 {
-    return MUL;
-  }
-
-  pub fn DIV() -> u64 {
-    return DIV;
-  }
-
-  pub fn MOD() -> u64 {
-    return MOD;
-  }
-
-  pub fn AND() -> u64 {
-    return AND;
-  }
-
-  pub fn OR() -> u64 {
-    return OR;
-  }
-
-  pub fn XOR() -> u64 {
-    return XOR;
-  }
-
-  pub fn SHL() -> u64 {
-    return SHL;
-  }
-
-  pub fn SHR() -> u64 {
-    return SHR;
-  }
-
-  pub fn LTN() -> u64 {
-    return LTN;
-  }
-
-  pub fn LTE() -> u64 {
-    return LTE;
-  }
-
-  pub fn EQL() -> u64 {
-    return EQL;
-  }
-
-  pub fn GTE() -> u64 {
-    return GTE;
-  }
-
-  pub fn GTN() -> u64 {
-    return GTN;
-  }
-
-  pub fn NEQ() -> u64 {
-    return NEQ;
-  }
-
-  pub fn CELLS_PER_KB() -> usize {
-    return CELLS_PER_KB;
-  }
-
-  pub fn CELLS_PER_MB() -> usize {
-    return CELLS_PER_MB; 
-  }
-
-  pub fn CELLS_PER_GB() -> usize {
-    return CELLS_PER_GB; 
-  }
-
-  pub fn get_tag(lnk: Ptr) -> u64 {
-    return get_tag(lnk);
-  }
-
-  pub fn get_ext(lnk: Ptr) -> u64 {
-    return get_ext(lnk);
-  }
-
-  pub fn get_val(lnk: Ptr) -> u64 {
-    return get_val(lnk);
-  }
-
-  pub fn get_num(lnk: Ptr) -> u64 {
-    return get_num(lnk);
-  }
-
-  pub fn get_loc(lnk: Ptr, arg: u64) -> u64 {
-    return get_loc(lnk, arg);
-  }
-
-  pub fn Var(pos: u64) -> Ptr {
-    return Var(pos);
-  }
-
-  pub fn Dp0(col: u64, pos: u64) -> Ptr {
-    return Dp0(col, pos);
-  }
-
-  pub fn Dp1(col: u64, pos: u64) -> Ptr {
-    return Dp1(col, pos);
-  }
-
-  pub fn Arg(pos: u64) -> Ptr {
-    return Arg(pos);
-  }
-
-  pub fn Era() -> Ptr {
-    return Era();
-  }
-
-  pub fn Lam(pos: u64) -> Ptr {
-    return Lam(pos);
-  }
-
-  pub fn App(pos: u64) -> Ptr {
-    return App(pos);
-  }
-
-  pub fn Sup(col: u64, pos: u64) -> Ptr {
-    return Sup(col, pos);
-  }
-
-  pub fn Op2(ope: u64, pos: u64) -> Ptr {
-    return Op2(ope, pos);
-  }
-
-  pub fn U6O(val: u64) -> Ptr {
-    return U6O(val);
-  }
-
-  pub fn F6O(val: u64) -> Ptr {
-    return F6O(val);
-  }
-
-  pub fn Ctr(fun: u64, pos: u64) -> Ptr {
-    return Ctr(fun, pos);
-  }
-
-  pub fn Fun(fun: u64, pos: u64) -> Ptr {
-    return Fun(fun, pos);
-  }
-
-  pub fn link(&mut self, loc: u64, lnk: Ptr) -> Ptr {
-    return link(&self.heap, loc, lnk);
-  }
-
-  pub fn alloc(&mut self, size: u64) -> u64 {
-    return alloc(&self.heap, 0, size); // FIXME tid?
-  }
-
-  pub fn free(&mut self, loc: u64, size: u64) {
-    return free(&self.heap, 0, loc, size); // FIXME tid?
-  }
-
-  pub fn collect(&mut self, term: Ptr) {
-    return collect(&self.heap, &self.prog.aris, 0, term); // FIXME tid?
-  }
-
 }
 
-// Methods that aren't compiled to JS
+impl RuntimeBuilder {
+    /// add a HVM rule to be interpreted by the runtime
+    pub fn add_rule(mut self, rule: language::syntax::Rule) -> Self {
+        self.rules.push(rule);
+        self
+    }
+
+    /// add multiple HVM rules at once
+    pub fn add_rules(mut self, rules: impl IntoIterator<Item = language::syntax::Rule>) -> Self {
+        self.rules.extend(rules.into_iter());
+        self
+    }
+
+    /// add a strictness mapping to a HVM rule,
+    /// where the `true` values corresponds to arguments that must be evaluated strictly.
+    ///
+    /// unless otherwise specifier, arguments of a constructor are evaluated lazily,
+    /// so this is useful for functions which cause side-effects.
+    pub fn add_strictness_map(mut self, name: String, map: impl IntoIterator<Item = bool>) -> Self {
+        self.strictness_maps.insert(name, map.into_iter().collect());
+        self
+    }
+
+    /// adds the rules written in the given HVM source code.
+    ///
+    /// returns the error message if the code failed to parse.
+    pub fn add_code(mut self, code: &str) -> Result<Self, String> {
+        let file = language::syntax::read_file(code)?;
+        self.rules.extend(file.rules);
+        for (name, smap) in file.smaps {
+            self.strictness_maps.insert(name, smap);
+        }
+        Ok(self)
+    }
+
+    /// add a function, prepared a head of time, which will be mapped to the given symbol
+    ///
+    /// allows precompilation of frequently used functions,
+    /// and including functionality that is not part of HVM by default, such as IO
+    pub fn add_function(mut self, name: String, func: Function) -> Self {
+        self.functions.insert(name, func);
+        self
+    }
+
+    /// sets the number of threads that will be used to reduce terms given to the runtime.
+    pub fn set_thread_count(mut self, thread_count: usize) -> Self {
+        self.thread_count = thread_count;
+        self
+    }
+
+    /// sets the size of the heap which stores the terms evaluated by the runtime,
+    /// given in the number of terms that can be stored on the heap.
+    ///
+    /// use [`CELLS_PER_KB`], [`CELLS_PER_MB`] and [`CELLS_PER_GB`],
+    /// to add values in terms of memory size.
+    pub fn set_heap_size(mut self, heap_size: usize) -> Self {
+        self.heap_size = heap_size;
+        self
+    }
+
+    /// causes evaluation of terms to print debug output,
+    /// showing how the given term was reduced step by step.
+    pub fn set_debug(mut self, debug: bool) -> Self {
+        self.debug = debug;
+        self
+    }
+
+    pub fn build(self) -> Runtime {
+        let file = language::syntax::File {
+            rules: self.rules,
+            smaps: self.strictness_maps.into_iter().collect(),
+        };
+
+        // Converts the file to a Rulebook
+        let book = language::rulebook::gen_rulebook(&file);
+
+        // Creates the runtime program
+        let mut program = Program::new();
+
+        // Adds the interpreted functions (from the Rulebook)
+        program.add_book(&book);
+
+        // Adds the extra functions
+        for (name, fun) in self.functions {
+            program.add_function(name, fun);
+        }
+
+        // Creates the runtime heap
+        let heap = new_heap(self.heap_size, self.thread_count);
+        let thread_ids = new_tids(self.thread_count);
+
+        Runtime {
+            heap,
+            program,
+            book,
+            thread_ids,
+            debug: self.debug,
+        }
+    }
+}
+
 impl Runtime {
-  /// Allocates a new term, returns its location
-  pub fn alloc_term(&mut self, term: &language::syntax::Term) -> u64 {
-    alloc_term(&self.heap, &self.prog, 0, &self.book, term) // FIXME tid?
-  }
+    /// reduces the term to Weak Head Normal Form,
+    /// meaning that applications in the term are evaluated,
+    /// untill the top level term is either a constructor, a function or a literal.
+    ///
+    /// constructors with strictly evaluated arguments,
+    /// will have those arguments similarly reduced.
+    pub fn reduce_term(&self, term: &language::syntax::Term) -> language::syntax::Term {
+        self.eval_term(term, false)
+    }
 
-  /// Given a location, recovers the Core stored on it
-  pub fn readback(&self, host: u64) -> Box<language::syntax::Term> {
-    language::readback::as_term(&self.heap, &self.prog, host)
-  }
+    /// reduces the term to Normal Form,
+    /// meaning that applications in the term are evaluated,
+    /// untill there are no more applications in the term.
+    pub fn normalize_term(&self, term: &language::syntax::Term) -> language::syntax::Term {
+        self.eval_term(term, true)
+    }
 
-  /// Given a location, recovers the Term stored on it
-  pub fn linear_readback(&self, host: u64) -> Box<language::syntax::Term> {
-    language::readback::as_linear_term(&self.heap, &self.prog, host)
-  }
+    fn eval_term(&self, term: &language::syntax::Term, normalize: bool) -> language::syntax::Term {
+        let tid = 0;
+
+        let host = alloc_term(&self.heap, &self.program, tid, &self.book, term);
+        let ptr = reduce(
+            &self.heap,
+            &self.program,
+            &self.thread_ids,
+            host,
+            normalize,
+            self.debug,
+        );
+
+        let output = language::readback::as_term(&self.heap, &self.program, host);
+
+        collect(&self.heap, &self.program.aris, tid, ptr);
+        *output
+    }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -191,6 +191,13 @@ impl Runtime {
         *output
     }
 
+    /// attempts to reduce the given term to the target type if possible.
+    /// on failure returns the error produced in the conversion of the reduced term.
+    pub fn eval_term<T, E>(&self, term: &language::syntax::Term) -> Result<T, E>
+    where language::syntax::Term: TryInto<T, Error=E> {
+        self.normalize_term(term).try_into()
+    }
+
     /// returns the number graph rewrites made by the runtime,
     /// since its initialization.
     ///

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -169,24 +169,10 @@ impl RuntimeBuilder {
 }
 
 impl Runtime {
-    /// reduces the term to Weak Head Normal Form,
-    /// meaning that applications in the term are evaluated,
-    /// untill the top level term is either a constructor, a function or a literal.
-    ///
-    /// constructors with strictly evaluated arguments,
-    /// will have those arguments similarly reduced.
-    pub fn reduce_term(&self, term: &language::syntax::Term) -> language::syntax::Term {
-        self.eval_term(term, false)
-    }
-
     /// reduces the term to Normal Form,
     /// meaning that applications in the term are evaluated,
     /// untill there are no more applications in the term.
     pub fn normalize_term(&self, term: &language::syntax::Term) -> language::syntax::Term {
-        self.eval_term(term, true)
-    }
-
-    fn eval_term(&self, term: &language::syntax::Term, normalize: bool) -> language::syntax::Term {
         let tid = 0;
 
         let host = alloc_term(&self.heap, &self.program, tid, &self.book, term);
@@ -195,7 +181,7 @@ impl Runtime {
             &self.program,
             &self.thread_ids,
             host,
-            normalize,
+            true,
             self.debug,
         );
 


### PR DESCRIPTION
this PR makes changes which are useful when using HVM directly as a library.

it adds functions for more easily constructing terms/rules directly, which is useful when converting other languages to HVM since the identifiers might not match what HVM expects when parsing from string.

it also changes the API for `Runtime` to be a high level interface for evaluating terms. it uses a builder pattern for setting the configuration of the runtime.
the comments suggest the runtime is used for WASM (though its unclear as there is no full description of it), so let me know if i need to move the interface to a separate file.

most of the details i figured out by reading the source code and running example code, since there wasn't much documentation.
i do shifting in `Term::float` because that is what was in the debug output after parsing a float with `read_term`.

i also don't know the significance of the `tid` when allocating a term (where is a thread being used here?), so i passed 0 since that's what the existing implementation does.

i am also not sure if `free` should be called when allocating a term, since it seems to be used for rules added with `link`