### PR TITLE
docs: Update GitHub repository URL in the README.md guide

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -14,7 +14,7 @@ rustup install nightly
 Then, install HVM:
 
 ```bash
-cargo +nightly install --force --git https://github.com/Kindelia/HVM.git
+cargo +nightly install --force --git https://github.com/HigherOrderCO/HVM.git
 ```
 
 This will install HVM's command-line interface. Make sure it worked with:


### PR DESCRIPTION
## Pull Request: Update GitHub Repository URL in README.md

### Description

This pull request addresses the need to update the GitHub repository URL in the README.md guide. The current URL is outdated, and this change reflects the correct repository URL.

### Changes Made

- Updated the GitHub repository URL in the README.md guide.

### Why?

The existing repository URL in the README.md file is pointing to an outdated location, causing confusion for users who try to install HVM. This update ensures that users are directed to the correct repository URL, improving the overall user experience.