### PR TITLE
fix overflow when compiling on machines with >64 cores

### DIFF
--- a/src/hvm.c
+++ b/src/hvm.c
@@ -39,7 +39,7 @@ typedef _Atomic(u64) a64;
 #ifndef TPC_L2
 #define TPC_L2 0
 #endif
-#define TPC (1 << TPC_L2)
+#define TPC (1ul << TPC_L2)
 
 // Types
 // -----
@@ -106,10 +106,10 @@ typedef u32 Numb; // Numb ::= 29-bit (rounded up to u32)
 #define CACHE_PAD 64
 
 // Global Net
-#define HLEN (1 << 16) // max 16k high-priority redexes
-#define RLEN (1 << 24) // max 16m low-priority redexes
-#define G_NODE_LEN (1 << 29) // max 536m nodes
-#define G_VARS_LEN (1 << 29) // max 536m vars
+#define HLEN (1ul << 16) // max 16k high-priority redexes
+#define RLEN (1ul << 24) // max 16m low-priority redexes
+#define G_NODE_LEN (1ul << 29) // max 536m nodes
+#define G_VARS_LEN (1ul << 29) // max 536m vars
 #define G_RBAG_LEN (TPC * RLEN)
 
 typedef struct Net {


### PR DESCRIPTION
```
  cargo:warning=src/hvm.c:113:25: warning: integer overflow in expression of type ‘int’ results in ‘-2147483648’ [-Woverflow]
  cargo:warning=  113 | #define G_RBAG_LEN (TPC * RLEN)
  cargo:warning=      |                         ^
  cargo:warning=src/hvm.c:118:18: note: in expansion of macro ‘G_RBAG_LEN’
  cargo:warning=  118 |   APair rbag_buf[G_RBAG_LEN]; // global rbag buffer
  cargo:warning=      |                  ^~~~~~~~~~
  cargo:warning=src/hvm.c:118:9: error: size of array ‘rbag_buf’ is negative
  cargo:warning=  118 |   APair rbag_buf[G_RBAG_LEN]; // global rbag buffer
  cargo:warning=      |         ^~~~~~~~
  cargo:warning=In file included from src/hvm.c:4:
  cargo:warning=src/hvm.c: In function ‘push_redex’:
  cargo:warning=src/hvm.c:113:25: warning: integer overflow in expression of type ‘int’ results in ‘-2147483648’ [-Woverflow]
  cargo:warning=  113 | #define G_RBAG_LEN (TPC * RLEN)
  cargo:warning=      |                         ^
  cargo:warning=src/hvm.c:538:51: note: in expansion of macro ‘G_RBAG_LEN’
  cargo:warning=  538 |     atomic_store_explicit(&net->rbag_buf[tm->tid*(G_RBAG_LEN/TPC) + (tm->rput++)], redex, memory_order_relaxed);
  cargo:warning=      |                                                   ^~~~~~~~~~
  cargo:warning=src/hvm.c: In function ‘pop_redex’:
  cargo:warning=src/hvm.c:113:25: warning: integer overflow in expression of type ‘int’ results in ‘-2147483648’ [-Woverflow]
  cargo:warning=  113 | #define G_RBAG_LEN (TPC * RLEN)
  cargo:warning=      |                         ^
  cargo:warning=src/hvm.c:546:61: note: in expansion of macro ‘G_RBAG_LEN’
  cargo:warning=  546 |     return atomic_exchange_explicit(&net->rbag_buf[tm->tid*(G_RBAG_LEN/TPC) + (--tm->rput)], 0, memory_order_relaxed);
  cargo:warning=      |                                                             ^~~~~~~~~~
  cargo:warning=src/hvm.c: In function ‘evaluator’:
  cargo:warning=src/hvm.c:113:25: warning: integer overflow in expression of type ‘int’ results in ‘-2147483648’ [-Woverflow]
  cargo:warning=  113 | #define G_RBAG_LEN (TPC * RLEN)
  cargo:warning=      |                         ^
  cargo:warning=src/hvm.c:1121:23: note: in expansion of macro ‘G_RBAG_LEN’
  cargo:warning= 1121 |       u32  idx = sid*(G_RBAG_LEN/TPC) + (tm->sidx++);
  cargo:warning=      |                       ^~~~~~~~~~
```