### PR TITLE
Make HVM available on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,41 +1,51 @@
 fn main() {
-
   let cores = num_cpus::get();
   let tpcl2 = (cores as f64).log2().floor() as u32;
 
-  match cc::Build::new()
+  let mut build = cc::Build::new();
+
+  // if with msvc
+  if cfg!(target_env = "msvc") {
+      build.flag("/experimental:c11atomics");
+  }
+
+  match build
       .file("src/hvm.c")
       .opt_level(3)
+      .std("c11")
       .warnings(false)
       .define("TPC_L2", &*tpcl2.to_string())
-      .try_compile("hvm-c") {
-    Ok(_) => println!("cargo:rerun-if-changed=src/hvm.c"),
-    Err(e) => {
-      println!("WARNING: Failed to compile hvm.c: {}", e);
-      println!("Ignoring hvm.c and proceeding with build.");
-    }
+      .try_compile("hvm-c")
+  {
+      Ok(_) => println!("cargo:rerun-if-changed=src/hvm.c"),
+      Err(e) => {
+          println!("WARNING: Failed to compile hvm.c: {}", e);
+          println!("Ignoring hvm.c and proceeding with build.");
+      }
   }
-
 
   // Builds hvm.cu
-  if std::process::Command::new("nvcc").arg("--version").stdout(std::process::Stdio::null()).stderr(std::process::Stdio::null()).status().is_ok() {
-  
-    if let Ok(cuda_path) = std::env::var("CUDA_HOME") {
-      println!("cargo:rustc-link-search=native={}/lib64", cuda_path);
-    } else {
-      println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
-    }
+  if std::process::Command::new("nvcc")
+      .arg("--version")
+      .stdout(std::process::Stdio::null())
+      .stderr(std::process::Stdio::null())
+      .status()
+      .is_ok()
+  {
+      if let Ok(cuda_path) = std::env::var("CUDA_HOME") {
+          println!("cargo:rustc-link-search=native={}/lib64", cuda_path);
+      } else {
+          println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
+      }
 
-    cc::Build::new()
-      .cuda(true)
-      .file("src/hvm.cu")
-      .compile("hvm-cu");
-    
-    println!("cargo:rerun-if-changed=src/hvm.cu");
-    println!("cargo:rustc-cfg=feature=\"cuda\"");   
-  }
-  else {
-    println!("WARNING: CUDA compiler not found. HVM will not be able to run on GPU.");
-  }
+      cc::Build::new()
+          .cuda(true)
+          .file("src/hvm.cu")
+          .compile("hvm-cu");
 
+      println!("cargo:rerun-if-changed=src/hvm.cu");
+      println!("cargo:rustc-cfg=feature=\"cuda\"");
+  } else {
+      println!("WARNING: CUDA compiler not found. HVM will not be able to run on GPU.");
+  }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,51 +1,49 @@
 fn main() {
-  let cores = num_cpus::get();
-  let tpcl2 = (cores as f64).log2().floor() as u32;
 
-  let mut build = cc::Build::new();
-
-  // if with msvc
-  if cfg!(target_env = "msvc") {
-      build.flag("/experimental:c11atomics");
-  }
-
-  match build
-      .file("src/hvm.c")
-      .opt_level(3)
-      .std("c11")
-      .warnings(false)
-      .define("TPC_L2", &*tpcl2.to_string())
-      .try_compile("hvm-c")
-  {
-      Ok(_) => println!("cargo:rerun-if-changed=src/hvm.c"),
+    let cores = num_cpus::get();
+    let tpcl2 = (cores as f64).log2().floor() as u32;
+  
+    println!("cargo:rerun-if-changed=src/hvm.c");
+    println!("cargo:rerun-if-changed=src/hvm.cu");
+  
+    let mut build = cc::Build::new();
+  
+    // if with msvc
+    if cfg!(target_env = "msvc") {
+        build.flag("/experimental:c11atomics");
+    }
+  
+    match build
+        .file("src/hvm.c")
+        .opt_level(3)
+        .std("c11")
+        .warnings(false)
+        .define("TPC_L2", &*tpcl2.to_string())
+        .try_compile("hvm-c") {
+      Ok(_) => println!("cargo:rustc-cfg=feature=\"c\""),
       Err(e) => {
-          println!("WARNING: Failed to compile hvm.c: {}", e);
-          println!("Ignoring hvm.c and proceeding with build.");
+        println!("cargo:warning=WARNING: Failed to compile hvm.c: {}", e);
+        println!("cargo:warning=Ignoring hvm.c and proceeding with build. The C runtime will not be available.");
       }
-  }
-
-  // Builds hvm.cu
-  if std::process::Command::new("nvcc")
-      .arg("--version")
-      .stdout(std::process::Stdio::null())
-      .stderr(std::process::Stdio::null())
-      .status()
-      .is_ok()
-  {
+    }
+  
+    // Builds hvm.cu
+    if std::process::Command::new("nvcc").arg("--version").stdout(std::process::Stdio::null()).stderr(std::process::Stdio::null()).status().is_ok() {
+    
       if let Ok(cuda_path) = std::env::var("CUDA_HOME") {
-          println!("cargo:rustc-link-search=native={}/lib64", cuda_path);
+        println!("cargo:rustc-link-search=native={}/lib64", cuda_path);
       } else {
-          println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
+        println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
       }
-
+  
       cc::Build::new()
-          .cuda(true)
-          .file("src/hvm.cu")
-          .compile("hvm-cu");
-
-      println!("cargo:rerun-if-changed=src/hvm.cu");
+        .cuda(true)
+        .file("src/hvm.cu")
+        .compile("hvm-cu");
       println!("cargo:rustc-cfg=feature=\"cuda\"");
-  } else {
-      println!("WARNING: CUDA compiler not found. HVM will not be able to run on GPU.");
+    }
+    else {
+      println!("cargo:warning=WARNING: CUDA compiler not found. HVM will not be able to run on GPU.");
+    }
+  
   }
-}

--- a/src/hvm.cu
+++ b/src/hvm.cu
@@ -346,13 +346,13 @@ const u32 G_RBAG_LEN = TPB * BPG * RLEN * 3; // max 4m redexes
 struct GNet {
   u32  rbag_use_A; // total rbag redex count (buffer A)
   u32  rbag_use_B; // total rbag redex count (buffer B)
-  Pair rbag_buf_A[G_RBAG_LEN]; // global redex bag (buffer A)
-  Pair rbag_buf_B[G_RBAG_LEN]; // global redex bag (buffer B)
-  Pair node_buf[G_NODE_LEN]; // global node buffer
-  Port vars_buf[G_VARS_LEN]; // global vars buffer
-  u32  node_put[TPB*BPG];
-  u32  vars_put[TPB*BPG];
-  u32  rbag_pos[TPB*BPG];
+  Pair* rbag_buf_A; // global redex bag (buffer A), size = G_RBAG_LEN
+  Pair* rbag_buf_B; // global redex bag (buffer B), size = G_RBAG_LEN
+  Pair* node_buf; // global node buffer, size = G_NODE_LEN
+  Port* vars_buf; // global vars buffer, size = G_VARS_LEN
+  u32*  node_put; // size = TPB*BPG
+  u32*  vars_put; // size = TPB*BPG
+  u32*  rbag_pos; // size = TPB*BPG
   u8   mode; // evaluation mode (curr)
   u64  itrs; // interaction count
   u64  iadd; // interaction count adder
@@ -1895,10 +1895,29 @@ __global__ void evaluator(GNet* gnet) {
 // -------------------
 
 GNet* gnet_create() {
-  GNet *gnet;
-  cudaMalloc((void**)&gnet, sizeof(GNet));
-  cudaMemset(gnet, 0, sizeof(GNet));
-  return gnet;
+  GNet gnet;
+  memset(&gnet, 0, sizeof(GNet));
+  
+  #define ALLOCATE_HOST_POINTER(__host_pointer, __size) \
+    do { \
+      cudaMalloc((void**)&(__host_pointer), __size); \
+      cudaMemset(__host_pointer, 0, __size); \
+    } while(0)
+
+  ALLOCATE_HOST_POINTER(gnet.rbag_buf_A, G_RBAG_LEN * sizeof(Pair));
+  ALLOCATE_HOST_POINTER(gnet.rbag_buf_B, G_RBAG_LEN * sizeof(Pair));
+  ALLOCATE_HOST_POINTER(gnet.node_buf, G_NODE_LEN * sizeof(Pair));
+  ALLOCATE_HOST_POINTER(gnet.vars_buf, G_VARS_LEN * sizeof(Port));
+  ALLOCATE_HOST_POINTER(gnet.node_put, BPG * TPB * sizeof(u32));
+  ALLOCATE_HOST_POINTER(gnet.vars_put, BPG * TPB * sizeof(u32));
+  ALLOCATE_HOST_POINTER(gnet.rbag_pos, BPG * TPB * sizeof(u32));
+
+  #undef ALLOCATE_HOST_POINTER
+
+  GNet* gnet_d;
+  cudaMalloc(&gnet_d, sizeof(GNet));
+  cudaMemcpy(gnet_d, &gnet, sizeof(GNet), cudaMemcpyHostToDevice);
+  return gnet_d;
 }
 
 u32 gnet_get_rlen(GNet* gnet, u32 turn) {


### PR DESCRIPTION
Get run-c and run-cu works on Windows 11. 
- `/experimental:c11atomics` and `-std=c11` is required for stdatomic
- Extremely large array (>=2GB) is not allowed on Windows so we have to use a pointer instead
- CUDA also needs some work for allocation
- threads.h rather than pthreads.h for compatibility.
- time64() with QueryPerformanceCounter()