### PR TITLE
Fix long function names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "809e18805660d7b6b2e2b9f316a5099521b5998d5cba4dda11b5157a21aaef03"
 
 [[package]]
 name = "hvm"
-version = "2.0.9"
+version = "2.0.11"
 dependencies = [
  "TSPL",
  "cc",

--- a/src/hvm.rs
+++ b/src/hvm.rs
@@ -926,8 +926,14 @@ impl Book {
 
       // Writes the name
       let name_bytes = def.name.as_bytes();
-      buf.extend_from_slice(&name_bytes[..32.min(name_bytes.len())]);
-      buf.resize(buf.len() + (32 - name_bytes.len()), 0);
+      if name_bytes.len() < 31 {
+        buf.extend_from_slice(&name_bytes[..name_bytes.len()]);
+        buf.resize(buf.len() + (32 - name_bytes.len()), 0);
+      } else {
+        buf.extend_from_slice(&name_bytes[..28]);
+        buf.extend_from_slice("...".as_bytes());
+        buf.push(0);
+      }
 
       // Writes the safe flag
       buf.extend_from_slice(&(def.safe as u32).to_ne_bytes());


### PR DESCRIPTION
Fixes #303. The threshold for truncating names is 31, not 32, since you need a byte for a null terminator.