### PR TITLE
Expose modules as a library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "809e18805660d7b6b2e2b9f316a5099521b5998d5cba4dda11b5157a21aaef03"
 
 [[package]]
 name = "hvm"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "TSPL",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ build = "build.rs"
 description = "A massively parallel, optimal functional runtime in Rust."
 license = "Apache-2.0"
 
+[lib]
+name = "hvm"
+path = "src/lib.rs"
+
 [dependencies]
 TSPL = "0.0.12"
 clap = "4.5.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod ast;
+pub mod cmp;
+pub mod hvm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,14 +3,11 @@
 #![allow(unused_variables)]
 
 use clap::{Arg, ArgAction, Command};
+use ::hvm::{ast, cmp, hvm};
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command as SysCommand;
-
-mod ast;
-mod cmp;
-mod hvm;
 
 #[cfg(feature = "c")]
 extern "C" {


### PR DESCRIPTION
This PR exposes the inner modules so that other projects can use HVM as a library. More focus on designing stabler APIs would be interesting in the future.