### PR TITLE
fix example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ syntax for wiring interaction nets. For example:
 @sum = (?(((a a) @sum__C0) b) b)
 
 @sum__C0 = ({c a} ({$([*2] $([+1] d)) $([*2] $([+0] b))} f))
-  &! @sum ~ (a (b $(:[+] $(e f))))
+  &! @sum ~ (a (b $([+] $(e f))))
   &! @sum ~ (c (d e))
 ```
 


### PR DESCRIPTION
In current, the example code in README can not be compiled:
```
❯ hvm run hello.hvm
thread 'main' panicked at /Users/gwo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hvm-2.0.15/src/main.rs:70:62:
PARSE_ERROR
- expected: name
- detected:
   7 |   &! @sum ~ (a (b $(:[+] $(e f))))
```

This PR will fix it.