### PR TITLE
HVM cli arg version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ extern "C" {
 fn main() {
   let matches = Command::new("hvm")
     .about("HVM2: Higher-order Virtual Machine 2 (32-bit Version)")
+    .version(env!("CARGO_PKG_VERSION"))
     .subcommand_required(true)
     .arg_required_else_help(true)
     .subcommand(


### PR DESCRIPTION
Hi!

This pull request introduces a new command-line argument -V to the HVM Rust project. The purpose of this argument is to print the current version of the application using the value specified in the Cargo package.

Changes:
    Added a new CLI argument -V.
    Implemented functionality to fetch and display the version from the Cargo package.

Details:
    Modified src/main.rs to include the -V argument.
    Utilized the env! macro to retrieve the version from Cargo.toml.
    Updated the help message to include the new -V option.

Usage:
    Running hvm -V will now print the current version of the application.

Motivation:
Adding the -V argument enhances the user experience by providing an easy way to check the application version directly from the command line. This aligns with common CLI conventions and improves usability.

Notes:
    No breaking changes introduced.

Please review the changes and provide feedback. 

Thank you!