### PR TITLE
Type-conversion SYMs

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -45,6 +45,10 @@ impl<'i> CoreParser<'i> {
 
     // Parses the symbol
     let op = hvm::Numb::new_sym(match () {
+      _ if self.try_consume("SYM") => hvm::TY_SYM,
+      _ if self.try_consume("U24") => hvm::TY_U24,
+      _ if self.try_consume("I24") => hvm::TY_I24,
+      _ if self.try_consume("F24") => hvm::TY_F24,
       _ if self.try_consume("+")   => hvm::OP_ADD,
       _ if self.try_consume("-")   => hvm::OP_SUB,
       _ if self.try_consume(":-")  => hvm::FP_SUB,
@@ -224,6 +228,10 @@ impl Numb {
     let numb = hvm::Numb(self.0);
     match numb.get_typ() {
       hvm::TY_SYM => match numb.get_sym() as hvm::Tag {
+        hvm::TY_SYM => "[SYM]".to_string(),
+        hvm::TY_U24 => "[U24]".to_string(),
+        hvm::TY_I24 => "[I24]".to_string(),
+        hvm::TY_F24 => "[F24]".to_string(),
         hvm::OP_ADD => "[+]".to_string(),
         hvm::OP_SUB => "[-]".to_string(),
         hvm::FP_SUB => "[:-]".to_string(),

--- a/src/hvm.c
+++ b/src/hvm.c
@@ -1735,6 +1735,10 @@ void pretty_print_numb(Numb word) {
   switch (get_typ(word)) {
     case TY_SYM: {
       switch (get_sym(word)) {
+        case TY_SYM: printf("[SYM]"); break;
+        case TY_U24: printf("[U24]"); break;
+        case TY_I24: printf("[I24]"); break;
+        case TY_F24: printf("[F24]"); break;
         case OP_ADD: printf("[+]"); break;
         case OP_SUB: printf("[-]"); break;
         case FP_SUB: printf("[:-]"); break;

--- a/src/hvm.cu
+++ b/src/hvm.cu
@@ -2185,6 +2185,10 @@ __device__ void pretty_print_numb(Numb word) {
   switch (get_typ(word)) {
     case TY_SYM: {
       switch (get_sym(word)) {
+        case TY_SYM: printf("[SYM]"); break;
+        case TY_U24: printf("[U24]"); break;
+        case TY_I24: printf("[I24]"); break;
+        case TY_F24: printf("[F24]"); break;
         case OP_ADD: printf("[+]"); break;
         case OP_SUB: printf("[-]"); break;
         case FP_SUB: printf("[:-]"); break;


### PR DESCRIPTION
Add SYMs for the numeric types and SYM itself to the parser and the printers for each runtime, to allow fast conversions between numeric types. Note that this functionality was already present in the runtimes, it just wasn't previously accessible.