### PR TITLE
Propagate unsafety to definitions that depend on unsafe definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ checksum = "809e18805660d7b6b2e2b9f316a5099521b5998d5cba4dda11b5157a21aaef03"
 
 [[package]]
 name = "hvm"
-version = "2.0.19"
+version = "2.0.20"
 dependencies = [
  "TSPL",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hvm"
 description = "A massively parallel, optimal functional runtime in Rust."
 license = "Apache-2.0"
-version = "2.0.19"
+version = "2.0.20"
 edition = "2021"
 rust-version = "1.74"
 build = "build.rs"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -524,7 +524,7 @@ impl Book {
     CoreParser::new(code).parse_book()
   }
 
-  pub fn build(&self) -> (hvm::Book, BTreeMap<String, usize>) {
+  pub fn build(&self) -> hvm::Book {
     let mut name_to_fid = BTreeMap::new();
     let mut fid_to_name = BTreeMap::new();
     fid_to_name.insert(0, "main".to_string());
@@ -552,7 +552,7 @@ impl Book {
       lookup.insert(name.clone(), book.defs.len() - 1);
     }
     self.propagate_safety(&mut book, &lookup);
-    return (book, lookup);
+    return book;
   }
 
   /// Propagate unsafe definitions to those that reference them.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -571,13 +571,13 @@ impl Book {
   /// nodes in weird places. See HVM issue [#362](https://github.com/HigherOrderCO/HVM/issues/362)
   /// for an example.
   fn propagate_safety(&self, compiled_book: &mut hvm::Book, lookup: &BTreeMap<String, u32>) {
-    let rev_dependencies = self.direct_dependents();
+    let dependents = self.direct_dependents();
     let mut stack: Vec<&str> = Vec::new();
 
     for (name, _) in self.defs.iter() {
       let def = &mut compiled_book.defs[lookup[name] as usize];
       if !def.safe {
-        for next in rev_dependencies[name.as_str()].iter() {
+        for next in dependents[name.as_str()].iter() {
           stack.push(next);
         }
       }
@@ -592,7 +592,7 @@ impl Book {
 
       def.safe = false;
 
-      for &next in rev_dependencies[curr].iter() {
+      for &next in dependents[curr].iter() {
         stack.push(next);
       }
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -577,9 +577,9 @@ impl Book {
     for (name, _) in self.defs.iter() {
       let def = &mut compiled_book.defs[lookup[name] as usize];
       if !def.safe {
-        stack.push(&name);
-        // Temporarily set as safe so we won't need a separate "visited" set
-        def.safe = true;
+        for next in rev_dependencies[name.as_str()].iter() {
+          stack.push(next);
+        }
       }
     }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -571,7 +571,7 @@ impl Book {
   /// nodes in weird places. See HVM issue [#362](https://github.com/HigherOrderCO/HVM/issues/362)
   /// for an example.
   fn propagate_safety(&self, compiled_book: &mut hvm::Book, lookup: &BTreeMap<String, u32>) {
-    let rev_dependencies = self.direct_dependencies_reversed();
+    let rev_dependencies = self.direct_dependents();
     let mut stack: Vec<&str> = Vec::new();
 
     for (name, _) in self.defs.iter() {
@@ -598,9 +598,9 @@ impl Book {
     }
   }
 
-  /// Calculates the dependencies of each definition but stores them reversed,
-  /// that is, if definition `A` requires `B`, `B: A` is in the return map.
-  /// This is used to propagate unsafe definitions to others that depend on them.
+  /// Calculates the dependents of each definition, that is, if definition `A`
+  /// requires `B`, `B: A` is in the return map. This is used to propagate unsafe
+  /// definitions to others that depend on them.
   /// 
   /// This solution has linear complexity on the number of definitions in the
   /// book and the number of direct references in each definition, but it also
@@ -610,7 +610,7 @@ impl Book {
   /// - `d` is the number of definitions in the book
   /// - `r` is the number of direct references in each definition
   /// - `t` is the number of nodes in each tree
-  fn direct_dependencies_reversed<'name>(&'name self) -> BTreeMap<&'name str, BTreeSet<&'name str>> {
+  fn direct_dependents<'name>(&'name self) -> BTreeMap<&'name str, BTreeSet<&'name str>> {
     let mut result = BTreeMap::new();
     for (name, _) in self.defs.iter() {
       result.insert(name.as_str(), BTreeSet::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,13 +68,13 @@ fn main() {
     Some(("run", sub_matches)) => {
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
-      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build().0;
+      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
       run(&book);
     }
     Some(("run-c", sub_matches)) => {
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
-      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build().0;
+      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
       let mut data : Vec<u8> = Vec::new();
       book.to_buffer(&mut data);
       #[cfg(feature = "c")]
@@ -87,7 +87,7 @@ fn main() {
     Some(("run-cu", sub_matches)) => {
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
-      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build().0;
+      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
       let mut data : Vec<u8> = Vec::new();
       book.to_buffer(&mut data);
       #[cfg(feature = "cuda")]
@@ -101,7 +101,7 @@ fn main() {
       // Reads book from file
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
-      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build().0;
+      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
 
       // Gets optimal core count
       let cores = num_cpus::get();
@@ -129,7 +129,7 @@ fn main() {
       // Reads book from file
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
-      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build().0;
+      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
 
       // Generates the interpreted book
       let mut book_buf : Vec<u8> = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,13 +68,13 @@ fn main() {
     Some(("run", sub_matches)) => {
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
-      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
+      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build().0;
       run(&book);
     }
     Some(("run-c", sub_matches)) => {
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
-      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
+      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build().0;
       let mut data : Vec<u8> = Vec::new();
       book.to_buffer(&mut data);
       //println!("{:?}", data);
@@ -89,7 +89,7 @@ fn main() {
     Some(("run-cu", sub_matches)) => {
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
-      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
+      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build().0;
       let mut data : Vec<u8> = Vec::new();
       book.to_buffer(&mut data);
       let run_io = sub_matches.get_flag("io");
@@ -104,7 +104,7 @@ fn main() {
       // Reads book from file
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
-      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
+      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build().0;
 
       // Gets optimal core count
       let cores = num_cpus::get();
@@ -135,7 +135,7 @@ fn main() {
       // Reads book from file
       let file = sub_matches.get_one::<String>("file").expect("required");
       let code = fs::read_to_string(file).expect("Unable to read file");
-      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build();
+      let book = ast::Book::parse(&code).unwrap_or_else(|er| panic!("{}",er)).build().0;
 
       // Generates the interpreted book
       let mut book_buf : Vec<u8> = Vec::new();

--- a/tests/programs/safety-check.hvm
+++ b/tests/programs/safety-check.hvm
@@ -1,0 +1,31 @@
+@List/Cons = (a (b ((@List/Cons/tag (a (b c))) c)))
+
+@List/Cons/tag = 1
+
+@List/Nil = ((@List/Nil/tag a) a)
+
+@List/Nil/tag = 0
+
+@id = (a a)
+
+@list = c
+  & @List/Cons ~ (1 (b c))
+  & @List/Cons ~ (2 (@List/Nil b))
+
+@main = b
+  & @map ~ (@main__C0 (a b))
+  & @List/Cons ~ (@id (@List/Nil a))
+
+@main__C0 = (a b)
+  & @map ~ (a (@list b))
+
+@map = (a ((@map__C1 (a b)) b))
+
+@map__C0 = (* (a (d ({(a b) c} f))))
+  & @List/Cons ~ (b (e f))
+  & @map ~ (c (d e))
+
+@map__C1 = (?(((* @List/Nil) @map__C0) a) a)
+
+// Test flags
+@test-rust-only = 1

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -45,6 +45,11 @@ fn test_file(path: &Path) {
   let rust_output = execute_hvm(&["run".as_ref(), path.as_os_str()], false).unwrap();
   assert_snapshot!(rust_output);
 
+  if contents.contains("@test-rust-only = 1") {
+    println!("only testing rust implementation for {path:?}");
+    return;
+  }
+
   println!("  testing {path:?}, C...");
   let c_output = execute_hvm(&["run-c".as_ref(), path.as_os_str()], false).unwrap();
   assert_eq!(c_output, rust_output, "{path:?}: C output does not match rust output");

--- a/tests/snapshots/run__file@empty.hvm.snap
+++ b/tests/snapshots/run__file@empty.hvm.snap
@@ -4,6 +4,6 @@ expression: rust_output
 input_file: tests/programs/empty.hvm
 ---
 exit status: 101
-thread 'main' panicked at src/ast.rs:527:41:
+thread 'main' panicked at src/ast.rs:542:41:
 missing `@main` definition
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/snapshots/run__file@empty.hvm.snap
+++ b/tests/snapshots/run__file@empty.hvm.snap
@@ -4,6 +4,6 @@ expression: rust_output
 input_file: tests/programs/empty.hvm
 ---
 exit status: 101
-thread 'main' panicked at src/ast.rs:542:41:
+thread 'main' panicked at src/ast.rs:547:41:
 missing `@main` definition
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/snapshots/run__file@safety-check.hvm.snap
+++ b/tests/snapshots/run__file@safety-check.hvm.snap
@@ -1,0 +1,6 @@
+---
+source: tests/run.rs
+expression: rust_output
+input_file: tests/programs/safety-check.hvm
+---
+ERROR: attempt to clone a non-affine global reference.


### PR DESCRIPTION
Related to #362.

This PR kind of fixes the issue, but not really. While this new version does return an error in the previously thought "correct" version of the program, which is expected since it actually performed unsafe operations, it doesn't error in the second version, which does the same. Returning an error in this version is much harder, since it's not cloning an unsafe definition, but an unsafe expression. According to Nicolas, that could be solved with an affine type system.