### PR TITLE
Use bool type from stdbool.h

### DIFF
--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -26,7 +26,7 @@ pub fn compile_book(trg: Target, book: &hvm::Book) -> String {
   for (fid, def) in book.defs.iter().enumerate() {
     code.push_str(&format!("    case {}: return interact_call_{}(net, tm, a, b);\n", fid, &def.name.replace("/","_").replace(".","_").replace("-","_")));
   }
-  code.push_str(&format!("    default: return FALSE;\n"));
+  code.push_str(&format!("    default: return false;\n"));
   code.push_str(&format!("  }}\n"));
   code.push_str(&format!("}}"));
 
@@ -70,7 +70,7 @@ pub fn compile_def(trg: Target, code: &mut String, book: &hvm::Book, tab: usize,
     code.push_str(&format!(" || !n{:x}", i));
   }
   code.push_str(&format!(") {{\n"));
-  code.push_str(&format!("{}return FALSE;\n", indent(tab+2)));
+  code.push_str(&format!("{}return false;\n", indent(tab+2)));
   code.push_str(&format!("{}}}\n", indent(tab+1)));
   for i in 0 .. def.vars {
     code.push_str(&format!("{}vars_create(net, v{:x}, NONE);\n", indent(tab+1), i));
@@ -79,7 +79,7 @@ pub fn compile_def(trg: Target, code: &mut String, book: &hvm::Book, tab: usize,
   // Allocs resources (using slow allocator)
   //code.push_str(&format!("{}// Allocates needed resources.\n", indent(tab+1)));
   //code.push_str(&format!("{}if (!get_resources(net, tm, {}, {}, {})) {{\n", indent(tab+1), def.rbag.len()+1, def.node.len(), def.vars));
-  //code.push_str(&format!("{}return FALSE;\n", indent(tab+2)));
+  //code.push_str(&format!("{}return false;\n", indent(tab+2)));
   //code.push_str(&format!("{}}}\n", indent(tab+1)));
   //for i in 0 .. def.node.len() {
     //code.push_str(&format!("{}Val n{:x} = tm->nloc[0x{:x}];\n", indent(tab+1), i, i));
@@ -102,7 +102,7 @@ pub fn compile_def(trg: Target, code: &mut String, book: &hvm::Book, tab: usize,
   }
 
   // Return
-  code.push_str(&format!("{}return TRUE;\n", indent(tab+1)));
+  code.push_str(&format!("{}return true;\n", indent(tab+1)));
   code.push_str(&format!("{}}}\n", indent(tab)));
 }
 

--- a/src/hvm.cu
+++ b/src/hvm.cu
@@ -22,9 +22,6 @@ typedef    float f32;
 typedef   double f64;
 typedef unsigned long long int u64;
 
-#define FALSE false
-#define TRUE  true
-
 // Configuration
 // -------------
 
@@ -1917,12 +1914,12 @@ bool book_load(Book* book, u32* buf) {
 
     if (def->rbag_len > L_NODE_LEN/TPB) {
       fprintf(stderr, "def '%s' has too many redexes: %u\n", def->name, def->rbag_len);
-      return FALSE;
+      return false;
     }
 
     if (def->node_len > L_NODE_LEN/TPB) {
       fprintf(stderr, "def '%s' has too many nodes: %u\n", def->name, def->node_len);
-      return FALSE;
+      return false;
     }
 
     // Reads root
@@ -1937,7 +1934,7 @@ bool book_load(Book* book, u32* buf) {
     buf += def->node_len * 2;
   }
 
-  return TRUE;
+  return true;
 }
 
 // Debug Printing

--- a/src/hvm.cuh
+++ b/src/hvm.cuh
@@ -7,7 +7,6 @@
 // Types
 // -----
 
-typedef uint8_t bool;
 typedef  uint8_t u8;
 typedef uint16_t u16;
 typedef uint32_t u32;

--- a/src/hvm.h
+++ b/src/hvm.h
@@ -3,11 +3,11 @@
 
 #include <math.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 // Types
 // -----
 
-typedef uint8_t bool;
 typedef  uint8_t  u8;
 typedef uint16_t u16;
 typedef uint32_t u32;

--- a/src/run.c
+++ b/src/run.c
@@ -65,7 +65,7 @@ Ctr readback_ctr(Net* net, Book* book, Port port) {
   ctr.tag = get_u24(get_val(arg_port));
 
   // Loads remaining arguments
-  while (TRUE) {
+  while (true) {
     app_port = expand(net, book, get_snd(app_node));
     if (get_tag(app_port) != CON) break;
     app_node = node_load(net, get_val(app_port));
@@ -107,7 +107,7 @@ Bytes readback_bytes(Net* net, Book* book, Port port) {
   bytes.len = 0;
 
   // Readback loop
-  while (TRUE) {
+  while (true) {
     // Normalizes the net
     normalize(net, book);
 
@@ -590,7 +590,7 @@ void do_run_io(Net* net, Book* book, Port port) {
   setlinebuf(stderr);
 
   // IO loop
-  while (TRUE) {
+  while (true) {
     // Normalizes the net
     normalize(net, book);
 

--- a/src/run.cu
+++ b/src/run.cu
@@ -65,7 +65,7 @@ Ctr gnet_readback_ctr(GNet* gnet, Port port) {
   ctr.tag = get_u24(get_val(arg_port));
 
   // Loads remaining arguments
-  while (TRUE) {
+  while (true) {
     app_port = gnet_expand(gnet, get_snd(app_node));
     if (get_tag(app_port) != CON) break;
     app_node = gnet_node_load(gnet, get_val(app_port));
@@ -109,7 +109,7 @@ extern "C" Bytes gnet_readback_bytes(GNet* gnet, Port port) {
   bytes.len = 0;
 
   // Readback loop
-  while (TRUE) {
+  while (true) {
     // Normalizes the net
     gnet_normalize(gnet);
 
@@ -626,7 +626,7 @@ void do_run_io(GNet* gnet, Book* book, Port port) {
   setlinebuf(stderr);
 
   // IO loop
-  while (TRUE) {
+  while (true) {
     // Normalizes the net
     gnet_normalize(gnet);
 


### PR DESCRIPTION
Defining `bool` ourselves can cause all sorts of problems. For example, if the implementation of the libraries we're using import another another definition of bool, HVM will not compile.

Or if a user tries to write FFI for HVM and includes a definition of bool.

One option was to `#define bool _Bool`, which is what stdbool does, but including the standard library is the more standard way of doing it.

Also, `hvm.cuh` tried to redefine `bool` in c++ which would cause an error.

Another effect is that we can now compile hvm with C23